### PR TITLE
[NEW] Add cve-exclusion.inc:

### DIFF
--- a/recipes-kernel/linux/cve-exclusion.inc
+++ b/recipes-kernel/linux/cve-exclusion.inc
@@ -1,0 +1,13770 @@
+CVE_STATUS[CVE-1999-0656] = "not-applicable-config: specific to ugidd, part of the old user-mode NFS server"
+
+CVE_STATUS[CVE-2006-2932] = "not-applicable-platform: specific to RHEL"
+
+CVE_STATUS[CVE-2007-2764] = "not-applicable-platform: specific to Sun/Brocade SilkWorm switches"
+
+CVE_STATUS[CVE-2007-4998] = "cpe-incorrect: a historic cp bug, no longer an issue as per https://bugzilla.redhat.com/show_bug.cgi?id=356471#c5"
+
+CVE_STATUS[CVE-2008-2544] = "disputed: not an issue as per https://bugzilla.redhat.com/show_bug.cgi?id=449089#c22"
+
+CVE_STATUS[CVE-2010-0298] = "fixed-version: 2.6.34 (1871c6)"
+
+CVE_STATUS[CVE-2014-2648] = "cpe-incorrect: not Linux"
+
+CVE_STATUS[CVE-2016-0774] = "ignored: result of incomplete backport"
+
+CVE_STATUS[CVE-2016-3695] = "not-applicable-platform: specific to RHEL with securelevel patches"
+
+CVE_STATUS[CVE-2016-3699] = "not-applicable-platform: specific to RHEL with securelevel patches"
+
+CVE_STATUS[CVE-2017-6264] = "not-applicable-platform: Android specific"
+
+CVE_STATUS[CVE-2017-1000377] = "not-applicable-platform: GRSecurity specific"
+
+CVE_STATUS[CVE-2018-6559] = "not-applicable-platform: Issue only affects Ubuntu"
+
+CVE_STATUS[CVE-2020-11935] = "not-applicable-config: Issue only affects aufs, which is not in linux-yocto"
+
+
+# Auto-generated CVE metadata, DO NOT EDIT BY HAND.
+# Generated at 2025-06-27 10:30:18.013060+00:00 for kernel version 6.14.5
+# From cvelistV5 cve_2025-06-27_0900Z-2-gdd13285d794
+
+
+python check_kernel_cve_status_version() {
+    this_version = "6.14.5"
+    kernel_version = d.getVar("LINUX_VERSION")
+    if kernel_version != this_version:
+        bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
+}
+do_cve_check[prefuncs] += "check_kernel_cve_status_version"
+
+CVE_STATUS[CVE-2019-25160] = "fixed-version: Fixed from version 5.0"
+
+CVE_STATUS[CVE-2019-25162] = "fixed-version: Fixed from version 6.0"
+
+# CVE-2019-3459 has no known resolution
+
+# CVE-2019-3460 has no known resolution
+
+CVE_STATUS[CVE-2020-36775] = "fixed-version: Fixed from version 5.7"
+
+CVE_STATUS[CVE-2020-36776] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2020-36777] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2020-36778] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2020-36779] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2020-36780] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2020-36781] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2020-36782] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2020-36783] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2020-36784] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2020-36785] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2020-36786] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2020-36787] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2020-36788] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2020-36789] = "fixed-version: Fixed from version 5.10"
+
+CVE_STATUS[CVE-2020-36790] = "fixed-version: Fixed from version 5.9"
+
+CVE_STATUS[CVE-2020-36791] = "fixed-version: Fixed from version 5.5.14"
+
+# CVE-2021-28688 has no known resolution
+
+# CVE-2021-28691 has no known resolution
+
+# CVE-2021-28711 has no known resolution
+
+# CVE-2021-28712 has no known resolution
+
+# CVE-2021-28713 has no known resolution
+
+# CVE-2021-28714 has no known resolution
+
+# CVE-2021-28715 has no known resolution
+
+CVE_STATUS[CVE-2021-46904] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46905] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46906] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46908] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46909] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46910] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46911] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46912] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46913] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46914] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46915] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46916] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46917] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46918] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46919] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46920] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46921] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-46922] = "fixed-version: Fixed from version 5.11.17"
+
+CVE_STATUS[CVE-2021-46923] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46924] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46925] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46926] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46927] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46928] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46929] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46930] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46931] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46932] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46933] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46934] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46935] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46936] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46937] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-46938] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46939] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46940] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46941] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46942] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46943] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46944] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46945] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46947] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46948] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46949] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46950] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46951] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46952] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46953] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46954] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46955] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46956] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46957] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46958] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46959] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46960] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46961] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46962] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46963] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46964] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46965] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46966] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46967] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46968] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46969] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46970] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46971] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46972] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46973] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46974] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46976] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46977] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46978] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46979] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46980] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46981] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46982] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46983] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46984] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46985] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46986] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46987] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46988] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46989] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46990] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46991] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46992] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46993] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46994] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46995] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46996] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46997] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46998] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-46999] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47000] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47001] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47002] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47003] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47004] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47005] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47006] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47007] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47008] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47009] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47010] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47011] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47012] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47013] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47014] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47015] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47016] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47017] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47018] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47019] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47020] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47021] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47022] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47023] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47024] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47025] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47026] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47027] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47028] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47029] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47030] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47031] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47032] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47033] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47034] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47035] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47036] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47037] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47038] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47039] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47040] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47041] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47042] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47043] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47044] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47045] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47046] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47047] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47048] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47049] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47050] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47051] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47052] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47053] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47054] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47055] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47056] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47057] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47058] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47059] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47060] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47061] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47062] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47063] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47064] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47065] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47066] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47067] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47068] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47069] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47070] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47071] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47072] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47073] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47074] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47075] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47076] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47077] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47078] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47079] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47080] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47081] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47082] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47083] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47086] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47087] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47088] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47089] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47090] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47091] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47092] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47093] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47094] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47095] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47096] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47097] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47098] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47099] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47100] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47101] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47102] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47103] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47104] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47105] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47106] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47107] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47108] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47109] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47110] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47111] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47112] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47113] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47114] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47116] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47117] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47118] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47119] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47120] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47121] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47122] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47123] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47124] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47125] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47126] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47127] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47128] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47129] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47130] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47131] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47132] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47133] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47134] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47135] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47136] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47137] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47138] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47139] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47140] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47141] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47142] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47143] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47145] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47146] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47147] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47148] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47149] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47150] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47151] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47152] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47153] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47158] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47159] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47160] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47161] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47162] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47163] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47164] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47165] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47166] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47167] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47168] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47169] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47170] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47171] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47172] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47173] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47174] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47175] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47176] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47177] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47178] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47179] = "fixed-version: Fixed from version 5.12.9"
+
+CVE_STATUS[CVE-2021-47180] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47181] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47182] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47183] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47184] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47185] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47186] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47187] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47188] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47189] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47190] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47191] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47192] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47193] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47194] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47195] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47196] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47197] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47198] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47199] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47200] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47201] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47202] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47203] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47204] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47205] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47206] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47207] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47209] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47210] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47211] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47212] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47214] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47215] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47216] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47217] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47218] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47219] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47221] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47222] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47223] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47224] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47225] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47226] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47227] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47228] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47229] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47230] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47231] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47232] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47233] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47234] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47235] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47236] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47237] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47238] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47239] = "fixed-version: Fixed from version 5.12.13"
+
+CVE_STATUS[CVE-2021-47240] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47241] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47242] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47243] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47244] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47245] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47246] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47247] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47248] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47249] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47250] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47251] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47252] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47253] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47254] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47255] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47256] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47257] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47258] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47259] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47260] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47261] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47262] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47263] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47264] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47265] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47266] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47267] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47268] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47269] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47270] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47271] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47272] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47273] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47274] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47275] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47276] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47277] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47278] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47279] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47280] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47281] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47282] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47283] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47284] = "fixed-version: Fixed from version 5.13"
+
+CVE_STATUS[CVE-2021-47286] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47287] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47288] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47289] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47290] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47291] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47292] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47293] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47294] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47295] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47296] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47297] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47298] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47299] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47300] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47301] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47302] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47303] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47304] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47305] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47306] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47307] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47308] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47309] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47310] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47311] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47312] = "fixed-version: Fixed from version 5.13.5"
+
+CVE_STATUS[CVE-2021-47313] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47314] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47315] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47316] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47317] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47318] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47319] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47320] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47321] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47322] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47323] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47324] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47325] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47327] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47328] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47329] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47330] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47331] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47332] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47333] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47334] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47335] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47336] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47337] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47338] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47339] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47340] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47341] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47342] = "fixed-version: Fixed from version 5.10.77"
+
+CVE_STATUS[CVE-2021-47343] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47344] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47345] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47346] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47347] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47348] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47349] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47350] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47351] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47352] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47353] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47354] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47355] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47356] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47357] = "fixed-version: Fixed from version 5.14"
+
+CVE_STATUS[CVE-2021-47358] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47359] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47360] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47361] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47362] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47363] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47364] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47365] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47366] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47367] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47368] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47369] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47370] = "fixed-version: Fixed from version 5.14.9"
+
+CVE_STATUS[CVE-2021-47371] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47372] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47373] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47374] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47375] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47376] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47378] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47379] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47380] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47381] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47382] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47383] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47384] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47385] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47386] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47387] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47388] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47389] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47390] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47391] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47392] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47393] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47394] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47395] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47396] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47397] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47398] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47399] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47400] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47401] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47402] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47403] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47404] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47405] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47406] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47407] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47408] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47409] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47410] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47412] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47413] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47414] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47415] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47416] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47417] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47418] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47419] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47420] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47421] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47422] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47423] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47424] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47425] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47426] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47427] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47428] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47429] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47430] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47431] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47432] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2021-47433] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47434] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47435] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47436] = "fixed-version: Fixed from version 5.14.14"
+
+CVE_STATUS[CVE-2021-47437] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47438] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47439] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47440] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47441] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47442] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47443] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47444] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47445] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47446] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47447] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47448] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47449] = "fixed-version: Fixed from version 5.14.14"
+
+CVE_STATUS[CVE-2021-47450] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47451] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47452] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47453] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47454] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47455] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47456] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47457] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47458] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47459] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47460] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47461] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47462] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47463] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47464] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47465] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47466] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47467] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47468] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47470] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47471] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47473] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47474] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47475] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47476] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47477] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47478] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47479] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47480] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47481] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47482] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47483] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47484] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47485] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47486] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47489] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47490] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47491] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47492] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47493] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47494] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47495] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47496] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47497] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47498] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-47499] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47500] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47501] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47502] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47503] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47504] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47505] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47506] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47507] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47508] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47509] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47510] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47511] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47512] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47513] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47514] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47515] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47516] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47517] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47518] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47519] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47520] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47521] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47522] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47523] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47524] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47525] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47526] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47527] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47528] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47529] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47530] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47531] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47532] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47533] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47534] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47535] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47536] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47537] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47538] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47539] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47540] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47541] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47542] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47544] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47546] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47547] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47548] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47549] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47550] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47551] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47552] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47553] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47554] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47555] = "fixed-version: Fixed from version 5.15.6"
+
+CVE_STATUS[CVE-2021-47556] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47557] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47558] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47559] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47560] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47561] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47562] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47563] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47564] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47565] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47566] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47567] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47568] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47569] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47570] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47571] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47572] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47576] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47577] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47578] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47579] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47580] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47582] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47583] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47584] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47585] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47586] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47587] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47588] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47589] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47590] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47591] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47592] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47593] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47594] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47595] = "fixed-version: Fixed from version 5.15.11"
+
+CVE_STATUS[CVE-2021-47596] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47597] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47598] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47599] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47600] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47601] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47602] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47603] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47604] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47605] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47606] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47607] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47608] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47609] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47610] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47611] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47612] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47613] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47614] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47616] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-47617] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2021-47618] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2021-47619] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2021-47620] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2021-47622] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2021-47623] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2021-47624] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2021-47631] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47632] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47633] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47634] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47635] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47636] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47637] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47638] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47639] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47640] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47641] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47642] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47643] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47644] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47645] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47646] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47647] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47648] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47649] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47650] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47651] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47652] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47653] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47654] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47655] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47656] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47657] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2021-47658] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2021-47659] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2021-47660] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2021-47668] = "fixed-version: Fixed from version 5.11"
+
+CVE_STATUS[CVE-2021-47669] = "fixed-version: Fixed from version 5.11"
+
+CVE_STATUS[CVE-2021-47670] = "fixed-version: Fixed from version 5.11"
+
+CVE_STATUS[CVE-2021-47671] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-4439] = "fixed-version: Fixed from version 5.15"
+
+CVE_STATUS[CVE-2021-4440] = "fixed-version: Fixed from version 5.10.218"
+
+CVE_STATUS[CVE-2021-4441] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2021-4442] = "fixed-version: Fixed from version 5.12"
+
+CVE_STATUS[CVE-2021-4453] = "fixed-version: Fixed from version 5.16"
+
+CVE_STATUS[CVE-2021-4454] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-21546] = "fixed-version: Fixed from version 5.19"
+
+# CVE-2022-26365 has no known resolution
+
+# CVE-2022-33740 has no known resolution
+
+# CVE-2022-33741 has no known resolution
+
+# CVE-2022-33742 has no known resolution
+
+# CVE-2022-33743 has no known resolution
+
+# CVE-2022-33744 has no known resolution
+
+# CVE-2022-3643 has no known resolution
+
+# CVE-2022-42328 has no known resolution
+
+# CVE-2022-42329 has no known resolution
+
+CVE_STATUS[CVE-2022-48626] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48627] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-48628] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2022-48629] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48630] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-48631] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48632] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48633] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48634] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48635] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48636] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48637] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48638] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48639] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48640] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48641] = "fixed-version: Fixed from version 5.19.12"
+
+CVE_STATUS[CVE-2022-48642] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48643] = "fixed-version: Fixed from version 5.19.12"
+
+CVE_STATUS[CVE-2022-48644] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48645] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48646] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48647] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48648] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48649] = "fixed-version: Fixed from version 5.19.12"
+
+CVE_STATUS[CVE-2022-48650] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48651] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48652] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48653] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48654] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48655] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48656] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48657] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48658] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48659] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48660] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48661] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48662] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48663] = "fixed-version: Fixed from version 5.19.12"
+
+CVE_STATUS[CVE-2022-48664] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48665] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48666] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48667] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48668] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48669] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2022-48670] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48671] = "fixed-version: Fixed from version 5.19.11"
+
+CVE_STATUS[CVE-2022-48672] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48673] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48674] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48675] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48686] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48687] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48688] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48689] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48690] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48691] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48692] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48693] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48694] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48695] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48696] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48697] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48698] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48699] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48701] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48702] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48703] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48704] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48705] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-48706] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48707] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48708] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48709] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48710] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-48711] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48712] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48713] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48714] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48715] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48716] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48717] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48718] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48719] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48720] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48721] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48722] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48723] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48724] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48725] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48726] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48727] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48728] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48729] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48730] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48731] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48732] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48733] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48734] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48735] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48738] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48739] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48740] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48741] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48742] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48743] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48744] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48745] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48746] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48747] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48748] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48749] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48750] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48751] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48752] = "fixed-version: Fixed from version 5.16.5"
+
+CVE_STATUS[CVE-2022-48753] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48754] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48755] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48756] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48757] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48758] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48759] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48760] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48761] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48762] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48763] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48764] = "fixed-version: Fixed from version 5.16.5"
+
+CVE_STATUS[CVE-2022-48765] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48766] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48767] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48768] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48769] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48770] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48771] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48772] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2022-48773] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48774] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48775] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48776] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48777] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48778] = "fixed-version: Fixed from version 5.16.11"
+
+CVE_STATUS[CVE-2022-48779] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48780] = "fixed-version: Fixed from version 5.16.11"
+
+CVE_STATUS[CVE-2022-48781] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48782] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48783] = "fixed-version: Fixed from version 5.16.11"
+
+CVE_STATUS[CVE-2022-48784] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48785] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48786] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48787] = "fixed-version: Fixed from version 5.16.11"
+
+CVE_STATUS[CVE-2022-48788] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48789] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48790] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48791] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48792] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48793] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48794] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48795] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48796] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48797] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48798] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48799] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48800] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48801] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48802] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48803] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48804] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48805] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48806] = "fixed-version: Fixed from version 5.16.10"
+
+CVE_STATUS[CVE-2022-48807] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48808] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48809] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48810] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48811] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48812] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48813] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48814] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48815] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48816] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48817] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48818] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48819] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48820] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48821] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48822] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48823] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48824] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48825] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48826] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48827] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48828] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48829] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48830] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48831] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48832] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48833] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48834] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48835] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48836] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48837] = "fixed-version: Fixed from version 5.16.17"
+
+CVE_STATUS[CVE-2022-48838] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48839] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48840] = "fixed-version: Fixed from version 5.16.17"
+
+CVE_STATUS[CVE-2022-48841] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48842] = "fixed-version: Fixed from version 5.16.16"
+
+CVE_STATUS[CVE-2022-48843] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48844] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48845] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48846] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48847] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48848] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48849] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48850] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48851] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48852] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48853] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48854] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48855] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48856] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48857] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48858] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48859] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48860] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48861] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48862] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48863] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48864] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48865] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48866] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48867] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48868] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48869] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48870] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48871] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48872] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48873] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48874] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48875] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48876] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48877] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48878] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48879] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48880] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48881] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48882] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48883] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48884] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48885] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48886] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48887] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48888] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48889] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48890] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48891] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48892] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48893] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48894] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48895] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48896] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48897] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48898] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48899] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48901] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48902] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48903] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48904] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48905] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48906] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48907] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48908] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48909] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48910] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48911] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48912] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48913] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48914] = "fixed-version: Fixed from version 5.16.13"
+
+CVE_STATUS[CVE-2022-48915] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48916] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48918] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48919] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48920] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48921] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48922] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48923] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48924] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48925] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48926] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48927] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48928] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48929] = "fixed-version: Fixed from version 5.16.12"
+
+CVE_STATUS[CVE-2022-48930] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48931] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48932] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48933] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48934] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48935] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48937] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48938] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48939] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48940] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48941] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48942] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48943] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48944] = "fixed-version: Fixed from version 5.17"
+
+CVE_STATUS[CVE-2022-48945] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48946] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48947] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48948] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48949] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48950] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48951] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48952] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-48953] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48954] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48955] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48956] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48957] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48958] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48959] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48960] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48961] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48962] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48963] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48964] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48965] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48966] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48967] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48968] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48969] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48970] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48971] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48972] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48973] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48974] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48975] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48976] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48977] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48978] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48979] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48980] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48981] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48982] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48983] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48984] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48985] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48986] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48987] = "fixed-version: Fixed from version 6.0.13"
+
+CVE_STATUS[CVE-2022-48988] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48989] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48990] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48991] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48992] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48994] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48995] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48996] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48997] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48998] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-48999] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49000] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49001] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49002] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49003] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49004] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49005] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49006] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49007] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49008] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49009] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49010] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49011] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49012] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49013] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49014] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49015] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49016] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49017] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49018] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49019] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49020] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49021] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49022] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49023] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49024] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49025] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49026] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49027] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49028] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49029] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49030] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49031] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49032] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49033] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49034] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2022-49035] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49044] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49046] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49047] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49048] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49049] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49050] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49051] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49052] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49053] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49054] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49055] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49057] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49058] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49059] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49060] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49061] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49062] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49063] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49064] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49065] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49066] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49067] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49068] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49069] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49070] = "fixed-version: Fixed from version 5.17.3"
+
+CVE_STATUS[CVE-2022-49071] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49072] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49073] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49074] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49075] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49076] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49077] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49078] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49079] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49080] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49081] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49082] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49083] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49084] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49085] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49086] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49087] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49088] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49089] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49090] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49091] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49092] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49093] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49094] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49095] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49096] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49097] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49098] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49099] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49100] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49102] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49103] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49104] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49105] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49106] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49107] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49108] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49109] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49110] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49111] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49112] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49113] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49114] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49115] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49116] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49117] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49118] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49119] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49120] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49121] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49122] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49123] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49124] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49125] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49126] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49127] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49128] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49129] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49130] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49131] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49132] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49133] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49134] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49135] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49136] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49137] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49138] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49139] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49141] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49142] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49144] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49145] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49146] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49147] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49148] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49149] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49150] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49151] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49152] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49153] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49154] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49155] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49156] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49157] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49158] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49159] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49160] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49161] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49162] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49163] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49164] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49165] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49166] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49167] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49168] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49169] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49170] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49171] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49172] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49173] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49174] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49175] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49176] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49177] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49178] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49179] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49180] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49182] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49183] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49184] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49185] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49186] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49187] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49188] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49189] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49190] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49191] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49192] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49193] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49194] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49195] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49196] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49197] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49198] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49199] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49200] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49201] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49202] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49203] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49204] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49205] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49206] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49207] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49208] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49209] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49210] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49211] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49212] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49213] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49214] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49215] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49216] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49217] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49218] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49219] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49220] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49221] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49222] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49223] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49224] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49225] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49226] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49227] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49228] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49229] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49230] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49231] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49232] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49233] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49234] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49235] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49236] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49237] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49238] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49239] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49240] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49241] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49242] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49243] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49244] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49245] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49246] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49247] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49248] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49249] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49250] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49251] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49252] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49253] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49254] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49255] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49256] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49257] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49258] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49259] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49260] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49261] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49262] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49263] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49264] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49265] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49266] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49267] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49268] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49269] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49270] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49271] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49272] = "fixed-version: Fixed from version 5.17.2"
+
+CVE_STATUS[CVE-2022-49273] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49274] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49275] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49276] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49277] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49278] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49279] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49280] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49281] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49282] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49283] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49284] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49285] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49286] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49287] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49288] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49289] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49290] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49291] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49292] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49293] = "fixed-version: Fixed from version 5.18"
+
+CVE_STATUS[CVE-2022-49294] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49295] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49296] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49297] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49298] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49300] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49301] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49302] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49303] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49304] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49305] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49306] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49307] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49308] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49309] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49310] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49311] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49312] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49313] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49314] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49315] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49316] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49317] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49318] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49319] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49320] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49321] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49322] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49323] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49324] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49325] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49326] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49327] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49328] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49329] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49330] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49331] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49332] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49333] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49334] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49335] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49336] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49337] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49338] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49339] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49340] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49341] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49342] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49343] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49344] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49345] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49346] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49347] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49348] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49349] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49350] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49351] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49352] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49353] = "fixed-version: Fixed from version 5.18.4"
+
+CVE_STATUS[CVE-2022-49354] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49356] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49357] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49358] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49359] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49360] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49361] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49362] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49363] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49364] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49365] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49366] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49367] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49368] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49369] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49370] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49371] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49372] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49373] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49374] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49375] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49376] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49377] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49378] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49379] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49380] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49381] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49382] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49383] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49384] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49385] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49386] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49387] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49388] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49389] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49390] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49391] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49392] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49393] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49394] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49395] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49396] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49397] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49398] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49399] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49400] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49401] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49402] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49403] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49404] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49405] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49406] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49407] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49408] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49409] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49410] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49411] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49412] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49413] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49414] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49415] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49416] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49417] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49418] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49419] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49420] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49421] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49422] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49423] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49424] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49425] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49426] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49427] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49428] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49429] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49430] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49431] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49432] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49433] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49434] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49435] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49436] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49437] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49438] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49439] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49440] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49441] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49442] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49443] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49444] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49445] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49446] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49447] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49448] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49449] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49450] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49451] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49452] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49453] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49454] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49455] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49456] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49457] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49458] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49459] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49460] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49461] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49462] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49463] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49464] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49465] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49466] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49467] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49468] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49469] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49470] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49471] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49472] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49473] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49474] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49475] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49476] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49477] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49478] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49479] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49480] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49481] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49482] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49483] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49484] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49485] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49486] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49487] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49488] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49489] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49490] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49491] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49492] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49493] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49494] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49495] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49496] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49497] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49498] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49499] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49500] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49501] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49502] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49503] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49504] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49505] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49506] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49507] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49508] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49509] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49510] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49511] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49512] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49513] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49514] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49515] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49516] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49517] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49518] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49519] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49520] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49521] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49522] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49523] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49524] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49525] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49526] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49527] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49528] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49529] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49530] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49531] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49532] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49533] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49534] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49535] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49536] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49537] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49538] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49539] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49540] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49541] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49542] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49543] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49544] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49545] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49546] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49547] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49548] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49549] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49550] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49551] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49552] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49553] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49554] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49555] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49556] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49557] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49558] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49559] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49560] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49561] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49562] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49563] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49564] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49565] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49566] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49567] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49568] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49569] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49570] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49571] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49572] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49573] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49574] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49575] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49576] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49577] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49578] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49579] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49580] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49581] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49582] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49583] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49584] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49585] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49586] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49587] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49588] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49589] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49590] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49591] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49592] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49593] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49594] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49595] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49596] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49597] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49598] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49599] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49600] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49601] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49602] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49603] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49604] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49605] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49606] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49607] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49608] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49609] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49610] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49611] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49612] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49613] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49615] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49616] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49617] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49618] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49619] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49620] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49621] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49622] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49623] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49624] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49625] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49626] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49627] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49628] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49629] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49630] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49631] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49632] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49633] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49634] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49635] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49636] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49637] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49638] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49639] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49640] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49641] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49642] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49643] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49644] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49645] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49646] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49647] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49648] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49649] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49650] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49651] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49652] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49653] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49654] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49655] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49656] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49657] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49658] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49659] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49661] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49662] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49663] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49664] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49665] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49666] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49667] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49668] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49669] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49670] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49671] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49672] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49673] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49674] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49675] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49676] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49677] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49678] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49679] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49680] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49681] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49682] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49683] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49684] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49685] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49686] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49687] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49688] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49691] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49692] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49693] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49694] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49695] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49696] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49697] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49698] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49699] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49700] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49701] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49702] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49703] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49704] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49705] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49706] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49707] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49708] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49709] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49710] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49711] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49712] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49713] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49714] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49715] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49716] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49717] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49718] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49719] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49720] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49721] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49722] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49723] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49724] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49725] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49726] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49727] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49728] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49729] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49730] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49731] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49732] = "fixed-version: Fixed from version 5.19"
+
+CVE_STATUS[CVE-2022-49733] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49738] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49739] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49740] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49741] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49742] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49743] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49744] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49745] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49746] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49747] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49748] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49749] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49750] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49751] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49752] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49753] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49754] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49755] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49756] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49757] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49758] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49759] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49760] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49761] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2022-49762] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49763] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49764] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49765] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49766] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49767] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49768] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49769] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49770] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49771] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49772] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49773] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49774] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49775] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49776] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49777] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49778] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49779] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49780] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49781] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49782] = "fixed-version: Fixed from version 6.0.10"
+
+CVE_STATUS[CVE-2022-49783] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49784] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49785] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49786] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49787] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49788] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49789] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49790] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49791] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49792] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49793] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49794] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49795] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49796] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49797] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49798] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49799] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49800] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49801] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49802] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49803] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49804] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49805] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49806] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49807] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49808] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49809] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49810] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49811] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49812] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49813] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49814] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49815] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49817] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49818] = "fixed-version: Fixed from version 6.0.10"
+
+CVE_STATUS[CVE-2022-49819] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49820] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49821] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49822] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49823] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49824] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49825] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49826] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49827] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49828] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49829] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49830] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49831] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49832] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49833] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49834] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49835] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49836] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49837] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49838] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49839] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49840] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49841] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49842] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49844] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49845] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49846] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49847] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49848] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49849] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49850] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49851] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49852] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49853] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49854] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49855] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49857] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49858] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49859] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49860] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49861] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49862] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49863] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49864] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49865] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49866] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49867] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49868] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49869] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49870] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49871] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49872] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49873] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49874] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49875] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49876] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49877] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49878] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49879] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49880] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49881] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49882] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49883] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49884] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49885] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49886] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49887] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49888] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49889] = "fixed-version: Fixed from version 6.0.8"
+
+CVE_STATUS[CVE-2022-49890] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49891] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49892] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49893] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49894] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49895] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49896] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49898] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49899] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49900] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49901] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49902] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49903] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49904] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49905] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49906] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49907] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49908] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49909] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49910] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49911] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49912] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49913] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49914] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49915] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49916] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49917] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49918] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49919] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49920] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49921] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49922] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49923] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49924] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49925] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49926] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49927] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49928] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49929] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49930] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49931] = "fixed-version: Fixed from version 6.1"
+
+CVE_STATUS[CVE-2022-49932] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2022-49934] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49935] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49936] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49937] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49938] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49939] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49940] = "fixed-version: Fixed from version 5.19.8"
+
+CVE_STATUS[CVE-2022-49942] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49943] = "fixed-version: Fixed from version 5.19.8"
+
+CVE_STATUS[CVE-2022-49944] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49945] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49946] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49947] = "fixed-version: Fixed from version 5.19.8"
+
+CVE_STATUS[CVE-2022-49948] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49949] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49950] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49951] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49952] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49953] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49954] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49955] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49956] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49957] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49958] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49959] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49960] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49961] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49962] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49963] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49964] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49965] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49966] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49967] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49968] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49969] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49970] = "fixed-version: Fixed from version 5.19.8"
+
+CVE_STATUS[CVE-2022-49971] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49972] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49973] = "fixed-version: Fixed from version 5.19.8"
+
+CVE_STATUS[CVE-2022-49974] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49975] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49976] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49977] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49978] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49979] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49980] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49981] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49982] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49983] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49984] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49985] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49986] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49987] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49989] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49990] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49991] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49992] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49993] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49994] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49995] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49996] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49997] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49998] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-49999] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50000] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50001] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50002] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50003] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50004] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50005] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50006] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50007] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50008] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50009] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50010] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50011] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50012] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50013] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50014] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50015] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50016] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50017] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50019] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50020] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50021] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50022] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50023] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50024] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50025] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50026] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50027] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50028] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50029] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50030] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50031] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50032] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50033] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50034] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50035] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50036] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50037] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50038] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50039] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50040] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50041] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50042] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50043] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50044] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50045] = "fixed-version: Fixed from version 5.19.4"
+
+CVE_STATUS[CVE-2022-50046] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50047] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50048] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50049] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50050] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50051] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50052] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50053] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50054] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50055] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50056] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50057] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50058] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50059] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50060] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50061] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50062] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50063] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50064] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50065] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50066] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50067] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50068] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50069] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50070] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50071] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50072] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50073] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50074] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50075] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50076] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50077] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50078] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50079] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50080] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50082] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50083] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50084] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50085] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50086] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50087] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50088] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50089] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50090] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50091] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50092] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50093] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50094] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50095] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50096] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50097] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50098] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50099] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50100] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50101] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50102] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50103] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50104] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50105] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50106] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50107] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50108] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50109] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50110] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50111] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50112] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50113] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50114] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50115] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50116] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50117] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50118] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50119] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50120] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50121] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50122] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50123] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50124] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50125] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50126] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50127] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50129] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50130] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50131] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50132] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50133] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50134] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50135] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50136] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50137] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50138] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50139] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50140] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50141] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50142] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50143] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50144] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50145] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50146] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50147] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50148] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50149] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50151] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50152] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50153] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50154] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50155] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50156] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50157] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50158] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50159] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50160] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50161] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50162] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50163] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50164] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50165] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50166] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50167] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50168] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50169] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50170] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50171] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50172] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50173] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50174] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50175] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50176] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50177] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50178] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50179] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50181] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50182] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50183] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50184] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50185] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50186] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50187] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50188] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50189] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50190] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50191] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50192] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50193] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50194] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50195] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50196] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50197] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50198] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50199] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50200] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50201] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50202] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50203] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50204] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50205] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50206] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50207] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50208] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50209] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50210] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50211] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50212] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50213] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50214] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50215] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50217] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50218] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50219] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50220] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50221] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50222] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50223] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50224] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50225] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50226] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50227] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50228] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-50229] = "fixed-version: Fixed from version 6.0"
+
+# CVE-2022-50230 has no known resolution
+
+CVE_STATUS[CVE-2022-50231] = "fixed-version: Fixed from version 6.0"
+
+# CVE-2022-50232 has no known resolution
+
+# CVE-2023-34319 has no known resolution
+
+# CVE-2023-34324 has no known resolution
+
+# CVE-2023-46838 has no known resolution
+
+CVE_STATUS[CVE-2023-52433] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52434] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52435] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52436] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52438] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52439] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52440] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52441] = "fixed-version: Fixed from version 6.5"
+
+CVE_STATUS[CVE-2023-52442] = "fixed-version: Fixed from version 6.5"
+
+CVE_STATUS[CVE-2023-52443] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52444] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52445] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52446] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52447] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52448] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52449] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52450] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52451] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52452] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52453] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52454] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52455] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52456] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52457] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52458] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52459] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52460] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52461] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52462] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52463] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52464] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52465] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52467] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52468] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52469] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52470] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52471] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52472] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52473] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52474] = "fixed-version: Fixed from version 6.4"
+
+CVE_STATUS[CVE-2023-52475] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52476] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52477] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52478] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52479] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52480] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52481] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52482] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52483] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52484] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52485] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52486] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52487] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52488] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52489] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52490] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52491] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52492] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52493] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52494] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52495] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52497] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52498] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52499] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52500] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52501] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52502] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52503] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52504] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52505] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52506] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52507] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52508] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52509] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52510] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52511] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52512] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52513] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52515] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52516] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52517] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52518] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52519] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52520] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52522] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52523] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52524] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52525] = "fixed-version: Fixed from version 6.5.7"
+
+CVE_STATUS[CVE-2023-52526] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52527] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52528] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52529] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52530] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52531] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52532] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52559] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52560] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52561] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52562] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52563] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52564] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52565] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52566] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52567] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52568] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52569] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52570] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52571] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52572] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52573] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52574] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52576] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52577] = "fixed-version: Fixed from version 6.5.6"
+
+CVE_STATUS[CVE-2023-52578] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52580] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52581] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52582] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52583] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52584] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52585] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52586] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52587] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52588] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52589] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52590] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52591] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52593] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52594] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52595] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52596] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52597] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52598] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52599] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52600] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52601] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52602] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52603] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52604] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52606] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52607] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52608] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52609] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52610] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52611] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52612] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52613] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52614] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52615] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52616] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52617] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52618] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52619] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52620] = "fixed-version: Fixed from version 6.4"
+
+CVE_STATUS[CVE-2023-52621] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52622] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52623] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52624] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52625] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52626] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52627] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52628] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52629] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52631] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52632] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52633] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52634] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52635] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52636] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52637] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52638] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52639] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52640] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52641] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52642] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52643] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52644] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52645] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52646] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52647] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52648] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52649] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52650] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52652] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52653] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52654] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52655] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52656] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52657] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52658] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52659] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52660] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52661] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52662] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52663] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52664] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52667] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52668] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52669] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52670] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52671] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52672] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52673] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52674] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52675] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52676] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52677] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52678] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52679] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52680] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52681] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52682] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52683] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52684] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52686] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52687] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52688] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52689] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52690] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52691] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52692] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52693] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52694] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52695] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52696] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52697] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52698] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52699] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52700] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52701] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52702] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52703] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52704] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52705] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52706] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52707] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52708] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52730] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52731] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52732] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52735] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52736] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52737] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52738] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52739] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52740] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52741] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52742] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52743] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52744] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52745] = "fixed-version: Fixed from version 6.1.12"
+
+CVE_STATUS[CVE-2023-52746] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52747] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52748] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52749] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52750] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52751] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52752] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52753] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52754] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52755] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52757] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52760] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52761] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52762] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52763] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52764] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52765] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52766] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52767] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52768] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52769] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52770] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52771] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52772] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52773] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52774] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52775] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52776] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52777] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52778] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52779] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52780] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52781] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52782] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52783] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52784] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52785] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52786] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52787] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52788] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52789] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52790] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52791] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52792] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52794] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52795] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52796] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52797] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52798] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52799] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52800] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52801] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52803] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52804] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52805] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52806] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52807] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52808] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52809] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52810] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52811] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52812] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52813] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52814] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52815] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52816] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52817] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52818] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52819] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52821] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52825] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52826] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52827] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52828] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52829] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52831] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52832] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52833] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52834] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52835] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52836] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52837] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52838] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52839] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52840] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52841] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52842] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52843] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52844] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52845] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52846] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52847] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52848] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52849] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52850] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52851] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52852] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52853] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52854] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52855] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52856] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52857] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52858] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52859] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52860] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52861] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52862] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52863] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52864] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52865] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52866] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52867] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52868] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52869] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52870] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52871] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52872] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52873] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52874] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52875] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52876] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52877] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52878] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52879] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52880] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52881] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52882] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52883] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52884] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2023-52885] = "fixed-version: Fixed from version 6.5"
+
+CVE_STATUS[CVE-2023-52886] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52887] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2023-52888] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2023-52889] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2023-52893] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52894] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52895] = "fixed-version: Fixed from version 6.1.8"
+
+CVE_STATUS[CVE-2023-52896] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52897] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52898] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52899] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52900] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52901] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52902] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52903] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52904] = "fixed-version: Fixed from version 5.15.168"
+
+CVE_STATUS[CVE-2023-52905] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52906] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52907] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52908] = "fixed-version: Fixed from version 6.1.7"
+
+CVE_STATUS[CVE-2023-52909] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52910] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52911] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52912] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52913] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52914] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52915] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52916] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52918] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2023-52919] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52920] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2023-52921] = "fixed-version: Fixed from version 6.5"
+
+CVE_STATUS[CVE-2023-52922] = "fixed-version: Fixed from version 6.5"
+
+CVE_STATUS[CVE-2023-52923] = "fixed-version: Fixed from version 6.5"
+
+CVE_STATUS[CVE-2023-52924] = "fixed-version: Fixed from version 6.5"
+
+CVE_STATUS[CVE-2023-52925] = "fixed-version: Fixed from version 6.4.12"
+
+CVE_STATUS[CVE-2023-52926] = "fixed-version: Fixed from version 6.7"
+
+CVE_STATUS[CVE-2023-52927] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2023-52928] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52929] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52930] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52931] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52932] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52933] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52934] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52935] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52936] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52937] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52938] = "fixed-version: Fixed from version 6.1.11"
+
+CVE_STATUS[CVE-2023-52939] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52940] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52941] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52942] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52973] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52974] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52975] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52976] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52977] = "fixed-version: Fixed from version 6.1.11"
+
+CVE_STATUS[CVE-2023-52978] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52979] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52980] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52981] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52982] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52983] = "fixed-version: Fixed from version 6.1.11"
+
+CVE_STATUS[CVE-2023-52984] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52985] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52986] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52987] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52988] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52989] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52991] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52992] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52993] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52994] = "fixed-version: Fixed from version 6.1.9"
+
+CVE_STATUS[CVE-2023-52995] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52996] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52997] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52998] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-52999] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53000] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53001] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53002] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53003] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53004] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53005] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53006] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53007] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53008] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53009] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53010] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53011] = "fixed-version: Fixed from version 6.2"
+
+# CVE-2023-53012 has no known resolution
+
+CVE_STATUS[CVE-2023-53013] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53014] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53015] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53016] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53017] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53018] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53019] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53020] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53021] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53022] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53023] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53024] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53026] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53028] = "fixed-version: Fixed from version 6.1.8"
+
+CVE_STATUS[CVE-2023-53029] = "fixed-version: Fixed from version 6.1.8"
+
+CVE_STATUS[CVE-2023-53030] = "fixed-version: Fixed from version 6.1.8"
+
+CVE_STATUS[CVE-2023-53031] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53032] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53033] = "fixed-version: Fixed from version 6.2"
+
+CVE_STATUS[CVE-2023-53034] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2023-53035] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53036] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53037] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53038] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53039] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53040] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53041] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53042] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53043] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53044] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53045] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53046] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53047] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53048] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53049] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53050] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53051] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53052] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53053] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53054] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53055] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53056] = "fixed-version: Fixed from version 6.2.9"
+
+CVE_STATUS[CVE-2023-53057] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53058] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53059] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53060] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53061] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53062] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53064] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53065] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53066] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53067] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53068] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53069] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53070] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53071] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53072] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53073] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53074] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53075] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53077] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53078] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53079] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53080] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53081] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53082] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53083] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53084] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53085] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53086] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53087] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53088] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53089] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53090] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53091] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53092] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53093] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53094] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53095] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53096] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53097] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53098] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53099] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53100] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53101] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53102] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53103] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53105] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53106] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53107] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53108] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53109] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53110] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53111] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53112] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53113] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53114] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53115] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53116] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53117] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53118] = "fixed-version: Fixed from version 6.2.8"
+
+CVE_STATUS[CVE-2023-53119] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53120] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53121] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53123] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53124] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53125] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53126] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53127] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53128] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53131] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53132] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53133] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53134] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53135] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53136] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53137] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53138] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53139] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53140] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53141] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53142] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53143] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53144] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53145] = "fixed-version: Fixed from version 6.3"
+
+CVE_STATUS[CVE-2023-53146] = "fixed-version: Fixed from version 6.6"
+
+CVE_STATUS[CVE-2024-26581] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26582] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26583] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26584] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26585] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26586] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26587] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26588] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26589] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26590] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26591] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26592] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26593] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26594] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26595] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26596] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26597] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26598] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26599] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26600] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26601] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26602] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26603] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26604] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26605] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26606] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26607] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26608] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26610] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26611] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26612] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26614] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26615] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26616] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26617] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26618] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26619] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26620] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26621] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26622] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26623] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26625] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26626] = "fixed-version: Fixed from version 6.7.4"
+
+CVE_STATUS[CVE-2024-26627] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26629] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26630] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26631] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26632] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26633] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26634] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26635] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26636] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26637] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26638] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26640] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26641] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26642] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26643] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26644] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26645] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26646] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26647] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26648] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26649] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26651] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26652] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26653] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26654] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26655] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26656] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26657] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26658] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26659] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26660] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26661] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26662] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26663] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26664] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26665] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26666] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26667] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26668] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26669] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26670] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26671] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26672] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26673] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26674] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26675] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26676] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26677] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26678] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26679] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26680] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26681] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26682] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26683] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26684] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26685] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26686] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26687] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26688] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26689] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26690] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26691] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26692] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26693] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26694] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26695] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26696] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26697] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26698] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26699] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26700] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26702] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26703] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26704] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26705] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26706] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26707] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26708] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26709] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26710] = "fixed-version: Fixed from version 6.7.6"
+
+CVE_STATUS[CVE-2024-26711] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26712] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26714] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26715] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26716] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26717] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26718] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26719] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26721] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26722] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26723] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26724] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26725] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26726] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26727] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26728] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26729] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26730] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26731] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26732] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26733] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26734] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26735] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26736] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26737] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26738] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26739] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26740] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26741] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26742] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26743] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26744] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26745] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26746] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26747] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26748] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26749] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26750] = "fixed-version: Fixed from version 5.15.151"
+
+CVE_STATUS[CVE-2024-26751] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26752] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26753] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26754] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26755] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26756] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26757] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26758] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26759] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26760] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26761] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26762] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26763] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26764] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26765] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26766] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26767] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26768] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26769] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26770] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26771] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26772] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26773] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26774] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26775] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26776] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26777] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26778] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26779] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26780] = "fixed-version: Fixed from version 6.7.9"
+
+CVE_STATUS[CVE-2024-26781] = "fixed-version: Fixed from version 6.7.9"
+
+CVE_STATUS[CVE-2024-26782] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26783] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26784] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26785] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26786] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26787] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26788] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26789] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26790] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26791] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26792] = "fixed-version: Fixed from version 6.7.9"
+
+CVE_STATUS[CVE-2024-26793] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26795] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26796] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26797] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26798] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26799] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26800] = "fixed-version: Fixed from version 6.7.9"
+
+CVE_STATUS[CVE-2024-26801] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26802] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26803] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26804] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26805] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26806] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26807] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26808] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26809] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26810] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26811] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26812] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26813] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26814] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26815] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26816] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26817] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26818] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26820] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26822] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26823] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26824] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26825] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26826] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26828] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26829] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26830] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26831] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26832] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26833] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26834] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26835] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26836] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26837] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26838] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26839] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26840] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26841] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26842] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26843] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26844] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26845] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26846] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26847] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26849] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26850] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26851] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26852] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26853] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26854] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26855] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26856] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26857] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26858] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26859] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26860] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26861] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26862] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26863] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26864] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26865] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26866] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26867] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26868] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26869] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26870] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26871] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26872] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26873] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26874] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26875] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26876] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26877] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26878] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26879] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26880] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26881] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26882] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26883] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26884] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26885] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26886] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26887] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26888] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26889] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26890] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26891] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26892] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26893] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26894] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26895] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26896] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26897] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26898] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26899] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26900] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26901] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26902] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26903] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26906] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26907] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26909] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26910] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26911] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26912] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26913] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26914] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26915] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26916] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26917] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26918] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26919] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26920] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-26921] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26922] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26923] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26924] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26925] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26926] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26927] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26928] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26930] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26931] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26932] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26933] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26934] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26935] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26936] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26937] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26938] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26939] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26940] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26941] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26942] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26943] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26944] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26945] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26946] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26947] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26948] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26949] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26950] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26951] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26952] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26953] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26954] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26955] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26956] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26957] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26958] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26959] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26960] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26961] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26962] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26963] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26964] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26965] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26966] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26967] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26968] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26969] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26970] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26971] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26973] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26974] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26975] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26976] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26977] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26978] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26980] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26981] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26982] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26983] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26984] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26985] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26986] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26987] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26988] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26989] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26990] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26991] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26992] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26993] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26994] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26995] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26996] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26997] = "fixed-version: Fixed from version 6.8.8"
+
+CVE_STATUS[CVE-2024-26998] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-26999] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27000] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27001] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27002] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27003] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27004] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27005] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27006] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27007] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27008] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27009] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27010] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27011] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27012] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27013] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27014] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27015] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27016] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27017] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27018] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27019] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27020] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27021] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27022] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27023] = "fixed-version: Fixed from version 6.7.7"
+
+CVE_STATUS[CVE-2024-27024] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27025] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27026] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27027] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27028] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27029] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27030] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27031] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27032] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27033] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27034] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27035] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27036] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27037] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27038] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27039] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27040] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27041] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27042] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27043] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27044] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27045] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27046] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27047] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27048] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27049] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27050] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27051] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27052] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27053] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27054] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27056] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27057] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27058] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27059] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27060] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27061] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27062] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27063] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27064] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27065] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27066] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27067] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27068] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27069] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27070] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27071] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27072] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27073] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27074] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27075] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27076] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27077] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27078] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27079] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27080] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27388] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27389] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27390] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27391] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27392] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27393] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27394] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27395] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27396] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27397] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27398] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27399] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27400] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27401] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27402] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27403] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27404] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27405] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27406] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27407] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27408] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27409] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27410] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27411] = "fixed-version: Fixed from version 6.7.9"
+
+CVE_STATUS[CVE-2024-27412] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27413] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27414] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27415] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27416] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27417] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27418] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27419] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27431] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-27432] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27433] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27434] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27435] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27436] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-27437] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-31076] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-32936] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-33619] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-33621] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-33847] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-34027] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-34030] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-34777] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-35247] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-35784] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35785] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35786] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35787] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35789] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35790] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35791] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35792] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35793] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35794] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35795] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35796] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35797] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35798] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35799] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35800] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35801] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35803] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35804] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35805] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35806] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35807] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35808] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35809] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35810] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35811] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35813] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35814] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35815] = "fixed-version: Fixed from version 6.7.12"
+
+CVE_STATUS[CVE-2024-35816] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35817] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35818] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35819] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35821] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35822] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35823] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35824] = "fixed-version: Fixed from version 6.7.12"
+
+CVE_STATUS[CVE-2024-35825] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35826] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35827] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35828] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35829] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35830] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35831] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35832] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35833] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35834] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35835] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35836] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35837] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35838] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35839] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35840] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35841] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35842] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-35843] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35844] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35845] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35846] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35847] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35848] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35849] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35850] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35851] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35852] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35853] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35854] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35855] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35856] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35857] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35858] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35859] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35860] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35861] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35862] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35863] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35864] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35865] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35866] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35867] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35868] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35869] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35870] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35871] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35872] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35873] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35874] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35875] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35877] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35878] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35879] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35880] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35882] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35883] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35884] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35885] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35886] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35887] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35888] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35889] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35890] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35891] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35892] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35893] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35894] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35895] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35896] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35897] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35898] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35899] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35900] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35901] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35902] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35903] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35904] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35905] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35907] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35908] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35909] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35910] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35911] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35912] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35913] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35914] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35915] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35916] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35917] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35919] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35920] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35921] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35922] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35924] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35925] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35926] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35927] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35929] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35930] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35931] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35932] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35933] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35934] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35935] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35936] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35937] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35938] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35939] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35940] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35942] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35943] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35944] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35945] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35946] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35947] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35948] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35949] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35950] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35951] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35952] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35953] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35954] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35955] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35956] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35957] = "fixed-version: Fixed from version 6.8.7"
+
+CVE_STATUS[CVE-2024-35958] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35959] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35960] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35961] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35962] = "fixed-version: Fixed from version 6.8.7"
+
+CVE_STATUS[CVE-2024-35963] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35964] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35965] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35966] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35967] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35968] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35969] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35970] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35971] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35972] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35973] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35974] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35975] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35976] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35977] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35978] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35979] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35980] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35981] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35982] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35983] = "fixed-version: Fixed from version 6.8.9"
+
+CVE_STATUS[CVE-2024-35984] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35985] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35986] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35987] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35988] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35989] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35990] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35991] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35992] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35993] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35994] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35995] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35996] = "fixed-version: Fixed from version 6.8.9"
+
+CVE_STATUS[CVE-2024-35997] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35998] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-35999] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36000] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36001] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36002] = "fixed-version: Fixed from version 6.8.9"
+
+CVE_STATUS[CVE-2024-36003] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36004] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36005] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36006] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36007] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36008] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36009] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36010] = "fixed-version: Fixed from version 6.8"
+
+CVE_STATUS[CVE-2024-36011] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36012] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36013] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36014] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36015] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36016] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36017] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36018] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36019] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36020] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36021] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36023] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36024] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36025] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36026] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36027] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36028] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36029] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36030] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36031] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36032] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36033] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36244] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36270] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36281] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36286] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36288] = "fixed-version: Fixed from version 6.9.4"
+
+CVE_STATUS[CVE-2024-36476] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-36477] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36478] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36479] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36481] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36484] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36489] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36880] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36881] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36882] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36883] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36884] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36886] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36887] = "fixed-version: Fixed from version 6.8.10"
+
+CVE_STATUS[CVE-2024-36888] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36889] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36890] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36891] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36892] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36893] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36894] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36895] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36896] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36897] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36898] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36899] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36900] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36901] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36902] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36903] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36904] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36905] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36906] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36908] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36909] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36910] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36911] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36912] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36913] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36914] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36915] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36916] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36917] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36918] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36919] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36920] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36921] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36922] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36923] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36924] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36925] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36926] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36927] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36928] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36929] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36930] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36931] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36932] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36933] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36934] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36935] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36936] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36937] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36938] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36939] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36940] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36941] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36943] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36944] = "fixed-version: Fixed from version 6.8.10"
+
+CVE_STATUS[CVE-2024-36945] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36946] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36947] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36948] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36949] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36950] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36951] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36952] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36953] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36954] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36955] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36956] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36957] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36958] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36959] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36960] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36961] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36962] = "fixed-version: Fixed from version 6.8.10"
+
+CVE_STATUS[CVE-2024-36963] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36964] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36965] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36966] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-36967] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36968] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36969] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36970] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36971] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36972] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36973] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36974] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36975] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36976] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36977] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36978] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-36979] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-37021] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-37026] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-37078] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-37354] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-37356] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38306] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38381] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38384] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38385] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38388] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38390] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38538] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38539] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38540] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38541] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38542] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38543] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38544] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38545] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38546] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38547] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38548] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38549] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38550] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38551] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38552] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38553] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38554] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38555] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38556] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38557] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38558] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38559] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38560] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38561] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38562] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38563] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38564] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38565] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38566] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38567] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38568] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38569] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38570] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38571] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38572] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38573] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38574] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38575] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38576] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38577] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38578] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38579] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38580] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-38581] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-38582] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38583] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38584] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38585] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38586] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38587] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38588] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38589] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38590] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38591] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38592] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38593] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38594] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38595] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38596] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38597] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38598] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38599] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38600] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38601] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38602] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38603] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38604] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38605] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38606] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38607] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38608] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38609] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38610] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38611] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38612] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38613] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38614] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38615] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38616] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38617] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38618] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38619] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38620] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38621] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38622] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38623] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38624] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38625] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38626] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38627] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38628] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38629] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38630] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38631] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38632] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38633] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38634] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38635] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38636] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38637] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38659] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38661] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38662] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38663] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38664] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38667] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-38780] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39276] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39277] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39282] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-39291] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39292] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39293] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39296] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39298] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39301] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39371] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39461] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39462] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39463] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39464] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39465] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39466] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39467] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39468] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39469] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39470] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39471] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39472] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39473] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39474] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39475] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39476] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39477] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39478] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39479] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39480] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39481] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39482] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39483] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39484] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39485] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39486] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39487] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39488] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39489] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39490] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39491] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39492] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39493] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39494] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39495] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39496] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39497] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39498] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39499] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39500] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39502] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39503] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39504] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39505] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39506] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39507] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39508] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39509] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-39510] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40899] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40900] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40901] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40902] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40903] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40904] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40905] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40906] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40907] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40908] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40909] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40910] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40911] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40912] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40913] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40914] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40915] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40916] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40917] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40918] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40919] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40920] = "fixed-version: Fixed from version 6.9.6"
+
+CVE_STATUS[CVE-2024-40921] = "fixed-version: Fixed from version 6.9.6"
+
+CVE_STATUS[CVE-2024-40922] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40923] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40924] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40925] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40926] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40927] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40928] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40929] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40930] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40931] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40932] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40933] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40934] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40935] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40936] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40937] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40938] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40939] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40940] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40941] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40942] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40943] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40944] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40945] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40947] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40948] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40949] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40950] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40951] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40952] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40953] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40954] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40955] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40956] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40957] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40958] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40959] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40960] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40961] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40962] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40963] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40964] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40965] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40966] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40967] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40968] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40969] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40970] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40971] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40972] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40973] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40974] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40975] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40976] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40977] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40978] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40979] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40980] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40981] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40983] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40984] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40985] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40986] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40987] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40988] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40989] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40990] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40991] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40992] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40993] = "fixed-version: Fixed from version 6.9.7"
+
+CVE_STATUS[CVE-2024-40994] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40995] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40996] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40997] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40998] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-40999] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41000] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41001] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41002] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41003] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41004] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41005] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41006] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41007] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41008] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-41009] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41010] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41011] = "fixed-version: Fixed from version 6.9"
+
+CVE_STATUS[CVE-2024-41012] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41013] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-41014] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-41015] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-41016] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-41017] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-41018] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-41019] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-41020] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-41021] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-41022] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-41023] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41025] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41026] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41027] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41028] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41029] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41030] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41031] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41032] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41033] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41034] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41035] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41036] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41037] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41038] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41039] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41040] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41041] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41042] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41043] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41044] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41045] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41046] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41047] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41048] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41049] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41050] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41051] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41052] = "fixed-version: Fixed from version 6.9.10"
+
+CVE_STATUS[CVE-2024-41053] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41054] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41055] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41056] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41057] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41058] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41059] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41060] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41061] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41062] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41063] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41064] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41065] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41066] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41067] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41068] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41069] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41070] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41072] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41073] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41074] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41075] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41076] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41077] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41078] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41079] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41080] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41081] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41082] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41083] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41084] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41085] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41086] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41087] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41088] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41089] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41090] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-41091] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-41092] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41093] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41094] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41095] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41096] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41097] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41098] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-41149] = "fixed-version: Fixed from version 6.12.7"
+
+CVE_STATUS[CVE-2024-41932] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-41935] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-42063] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42064] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42065] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42066] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42067] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42068] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42069] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42070] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42071] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42072] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42073] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42074] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42075] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42076] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42077] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42078] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42079] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42080] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42081] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42082] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42083] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42084] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42085] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42086] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42087] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42088] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42089] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42090] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42091] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42092] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42093] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42094] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42095] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42096] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42097] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42098] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42099] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42100] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42101] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42102] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42103] = "fixed-version: Fixed from version 6.9.9"
+
+CVE_STATUS[CVE-2024-42104] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42105] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42106] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42107] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42108] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42109] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42110] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42111] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42112] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42113] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42114] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42115] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42117] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42118] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42119] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42120] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42121] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42122] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42123] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42124] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42125] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42126] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42127] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42128] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42129] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42130] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42131] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42132] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42133] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42134] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42135] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42136] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42137] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42138] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42139] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42140] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42141] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42142] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42144] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42145] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42146] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42147] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42148] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42149] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42150] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42151] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42152] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42153] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42154] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42155] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42156] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42157] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42158] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42159] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42160] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42161] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42162] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42223] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42224] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42225] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42227] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42228] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42229] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42230] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42231] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42232] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42233] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42234] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42235] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42236] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42237] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42238] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42239] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42240] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42241] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42242] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42243] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42244] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42245] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42246] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42247] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42248] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42249] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42250] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42251] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42252] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42253] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-42254] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42255] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42256] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42257] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42258] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42259] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42260] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42261] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42262] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42263] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42264] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42265] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42266] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42267] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42268] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42269] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42270] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42271] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42272] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42273] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42274] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42275] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42276] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42277] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42278] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42279] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42280] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42281] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42282] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42283] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42284] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42285] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42286] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42287] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42288] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42289] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42290] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42291] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42292] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42293] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42294] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42295] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42296] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42297] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42298] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42299] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42300] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42301] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42302] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42303] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42304] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42305] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42306] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42307] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42309] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42310] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42311] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42312] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42313] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42314] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42315] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42316] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42317] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42318] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42319] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42320] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42321] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-42322] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43098] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-43815] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43816] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43817] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43818] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43819] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43820] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43821] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43822] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43823] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43824] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43825] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43826] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43827] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43828] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43829] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43830] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43831] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43832] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43833] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43834] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43835] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43836] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43837] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43838] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43839] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43840] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43841] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43842] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43843] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43844] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43845] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43846] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43847] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43848] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43849] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43850] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43851] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43852] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43853] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43854] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43855] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43856] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43857] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43858] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43859] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43860] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43861] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43862] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43863] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43864] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43865] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43866] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43867] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43868] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43869] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43870] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43871] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43872] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43873] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43874] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43875] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43876] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43877] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43878] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43879] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43880] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43881] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43882] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43883] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43884] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43886] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43887] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43888] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43889] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43890] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43891] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43892] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43893] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43894] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43895] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43896] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43897] = "fixed-version: Fixed from version 6.10.5"
+
+CVE_STATUS[CVE-2024-43899] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43900] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43901] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43902] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43904] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43905] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43906] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43907] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43908] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43909] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43910] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43911] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43912] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43913] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-43914] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44931] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44932] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44933] = "fixed-version: Fixed from version 6.10.5"
+
+CVE_STATUS[CVE-2024-44934] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44935] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44936] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44937] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44938] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44939] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44940] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44941] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44942] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44943] = "fixed-version: Fixed from version 6.10"
+
+CVE_STATUS[CVE-2024-44944] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44945] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44946] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44947] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44948] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44949] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44950] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44951] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44953] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44954] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44956] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44957] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44958] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44959] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44960] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44961] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44962] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44963] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44964] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44965] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44966] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44967] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44968] = "fixed-version: Fixed from version 6.10.5"
+
+CVE_STATUS[CVE-2024-44969] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44970] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44971] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44972] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44973] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44974] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44975] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44976] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44977] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44978] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44979] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44980] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44981] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44982] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44983] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44984] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44985] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44986] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44987] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44988] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44989] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44990] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44991] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44992] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44993] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44994] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44995] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44996] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44997] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44998] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-44999] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45000] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45001] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45002] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45003] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45004] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45005] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45006] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45007] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45008] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45009] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45010] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45011] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45012] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45013] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45014] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45015] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45016] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45017] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45018] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45019] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45020] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45021] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45022] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45023] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45024] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45025] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45026] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45027] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45028] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45029] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45030] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-45828] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-46672] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46673] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46674] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46675] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46676] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46677] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46678] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46679] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46680] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46681] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46682] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46683] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46684] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46685] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46686] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46687] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46688] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46689] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46690] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46691] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46692] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46693] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46694] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46695] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46696] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46697] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46698] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46699] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46701] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46702] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46703] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46704] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46705] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46706] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46707] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46708] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46709] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46710] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46711] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46712] = "fixed-version: Fixed from version 6.10.8"
+
+CVE_STATUS[CVE-2024-46713] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46714] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46715] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46716] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46717] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46718] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46719] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46720] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46721] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46722] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46723] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46724] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46725] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46726] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46727] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46728] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46729] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46730] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46731] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46732] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46733] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46734] = "fixed-version: Fixed from version 6.10.10"
+
+CVE_STATUS[CVE-2024-46735] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46736] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46737] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46738] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46739] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46740] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46741] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46742] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46743] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46744] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46745] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46746] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46747] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46748] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46749] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46750] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46751] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46752] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46753] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46754] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46755] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46759] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46760] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46761] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46762] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46763] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46764] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46765] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46766] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46767] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46768] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46769] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46770] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46771] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46772] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46773] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46774] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46775] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46776] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46777] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46778] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46779] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46780] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46781] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46782] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46783] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46784] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46785] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46786] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46787] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46788] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46789] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46790] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46791] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46792] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46793] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46794] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46795] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46796] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46797] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46798] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46799] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46800] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46801] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46802] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46803] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46804] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46805] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46806] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46807] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46808] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46809] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46810] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46811] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46812] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46813] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46814] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46815] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46816] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46817] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46818] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46819] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46820] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46821] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46822] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46823] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46824] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46825] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46826] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46827] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46828] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46829] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46830] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46831] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46832] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46833] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46834] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46835] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46836] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46837] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46838] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46840] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46841] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46842] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46843] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46844] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46845] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46846] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46847] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46848] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46849] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46850] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46851] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46852] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46853] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46854] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46855] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46856] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46857] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46858] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46859] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46860] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46861] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46862] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46863] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46864] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46865] = "fixed-version: Fixed from version 6.10.11"
+
+CVE_STATUS[CVE-2024-46866] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46867] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46868] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46869] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-46870] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46871] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-46896] = "fixed-version: Fixed from version 6.12.7"
+
+CVE_STATUS[CVE-2024-47141] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-47143] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-47408] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-47658] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47659] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47660] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47661] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47662] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47663] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47664] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47665] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47666] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47667] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47668] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47669] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47670] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47671] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47672] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47673] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47674] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-47675] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47676] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47677] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47678] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47679] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47680] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47681] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47682] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47683] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47684] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47685] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47686] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47687] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47688] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47689] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47690] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47691] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47692] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47693] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47694] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47695] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47696] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47697] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47698] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47699] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47700] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47701] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47702] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47703] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47704] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47705] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47706] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47707] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47708] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47709] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47710] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47711] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47712] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47713] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47714] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47715] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47716] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47717] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47718] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47719] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47720] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47721] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47723] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47724] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47726] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47727] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47728] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47729] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47730] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47731] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47732] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47733] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47734] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47735] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47736] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47737] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47738] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47739] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47740] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47741] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47742] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47743] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47744] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47745] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47746] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47747] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47748] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47749] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47750] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47751] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47752] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47753] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47754] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47756] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47757] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-47794] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-47809] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-48873] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-48875] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-48876] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-48881] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-49568] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-49569] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-49570] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-49571] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-49573] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-49850] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49851] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49852] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49853] = "fixed-version: Fixed from version 6.12"
+
+# CVE-2024-49854 has no known resolution
+
+CVE_STATUS[CVE-2024-49855] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49856] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49857] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49858] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49859] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49860] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49861] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49862] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49863] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49864] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49865] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49866] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49867] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49868] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49869] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49870] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49871] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49872] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49873] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49874] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49875] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49876] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49877] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49878] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49879] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49880] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49881] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49882] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49883] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49884] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49885] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49886] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49887] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49888] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49889] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49890] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49891] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49892] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49893] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49894] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49895] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49896] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49897] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49898] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49899] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49900] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49901] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49902] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49903] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49904] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49905] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49906] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49907] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49908] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49909] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49910] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49911] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49912] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49913] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49914] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49915] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49916] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49917] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49918] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49919] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49920] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49921] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49922] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49923] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49924] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49925] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49926] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49927] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49928] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49929] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49930] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49931] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49932] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49933] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49934] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49935] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49936] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49937] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49938] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49939] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49940] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49941] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49942] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49943] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49944] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49945] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49946] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49947] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49948] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49949] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49950] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49951] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49952] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49953] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49954] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49955] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49956] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49957] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49958] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49959] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49960] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49961] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49962] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49963] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49964] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49965] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49966] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49968] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49969] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49970] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49971] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49972] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49973] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49974] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49975] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49976] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49977] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49978] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49979] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49980] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49981] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49982] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49983] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49984] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49985] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49986] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49987] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49988] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49989] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49990] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49991] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49992] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49994] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49996] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49997] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49998] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-49999] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50000] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50001] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50002] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50003] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50004] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50005] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50006] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50007] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50008] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50009] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50010] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50011] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50012] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50013] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50014] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50015] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50017] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50019] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50020] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50021] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50022] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50023] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50024] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50025] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50026] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50027] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50028] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50029] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50030] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50031] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50033] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50034] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50035] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50036] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50037] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50038] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50039] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50040] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50041] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50042] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50043] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50044] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50045] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50046] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50047] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50048] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50049] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50051] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-50055] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50056] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50057] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50058] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50059] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50060] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50061] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50062] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50063] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50064] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50065] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50066] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50067] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50068] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50069] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50070] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50071] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50072] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50073] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50074] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50075] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50076] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50077] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50078] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50079] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50080] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50081] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50082] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50083] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50084] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50085] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50086] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50087] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50088] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50090] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50091] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50092] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50093] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50094] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50095] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50096] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50097] = "fixed-version: Fixed from version 6.11.4"
+
+CVE_STATUS[CVE-2024-50098] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50099] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50100] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50101] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50102] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50103] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50104] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50105] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50106] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50107] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50108] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50109] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50110] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50111] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50112] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50113] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50114] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50115] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50116] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50117] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50118] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50119] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50120] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50121] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50122] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50123] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50124] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50125] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50126] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50127] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50128] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50129] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50130] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50131] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50132] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50133] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50134] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50135] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50136] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50137] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50138] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50139] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50140] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50141] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50142] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50143] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50144] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50145] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50146] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50147] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50148] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50149] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50150] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50151] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50152] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50153] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50154] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50155] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50156] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50157] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50158] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50159] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50160] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50161] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50162] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50163] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50164] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50165] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50166] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50167] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50168] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50169] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50170] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50171] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50172] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50173] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50174] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50175] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50176] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50177] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50178] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50179] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50180] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50182] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50183] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50184] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50185] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50186] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50187] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50188] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50189] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50190] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50191] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50192] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50193] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50194] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50195] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50196] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50197] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50198] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50199] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50200] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50201] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50202] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50203] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50204] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50205] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50206] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50207] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50208] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50209] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50210] = "fixed-version: Fixed from version 6.11.6"
+
+CVE_STATUS[CVE-2024-50211] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50212] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50213] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50214] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50215] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50216] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50217] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50218] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50220] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50221] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50222] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50223] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50224] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50225] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50226] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50227] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50229] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50230] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50231] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50232] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50233] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50234] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50235] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50236] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50237] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50238] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50239] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50240] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50241] = "fixed-version: Fixed from version 6.11.7"
+
+CVE_STATUS[CVE-2024-50242] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50243] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50244] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50245] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50246] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50247] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50248] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50249] = "fixed-version: Fixed from version 6.11.7"
+
+CVE_STATUS[CVE-2024-50250] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50251] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50252] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50253] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50254] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50255] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50256] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50257] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50258] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50259] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50260] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50261] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50262] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50263] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50264] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50265] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50266] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50267] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50268] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50269] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50270] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50271] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50272] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50273] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50274] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50275] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50276] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50277] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50278] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50279] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50280] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50281] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50282] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50283] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50284] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50285] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50286] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50287] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50288] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50289] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50290] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50291] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50292] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50293] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50294] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50295] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50296] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50297] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50298] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50299] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50300] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50301] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50302] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50303] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-50304] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-51729] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-52319] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-52332] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-52557] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-52559] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-52560] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-53042] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53043] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53044] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53045] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53046] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53047] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53048] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53049] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53050] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53051] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53052] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53053] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53055] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53056] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53057] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53058] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53059] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53060] = "fixed-version: Fixed from version 6.11.8"
+
+CVE_STATUS[CVE-2024-53061] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53062] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53063] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53064] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53065] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53066] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53067] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53068] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53069] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53070] = "fixed-version: Fixed from version 6.11.8"
+
+CVE_STATUS[CVE-2024-53071] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53072] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53073] = "fixed-version: Fixed from version 6.11.7"
+
+CVE_STATUS[CVE-2024-53074] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53075] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53076] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53077] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53078] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53079] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53080] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53081] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53082] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53083] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53084] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53085] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53086] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53087] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53088] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53089] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53090] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53091] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53092] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53093] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53094] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53095] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53096] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53097] = "fixed-version: Fixed from version 6.11.9"
+
+CVE_STATUS[CVE-2024-53098] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53099] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53100] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53101] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53103] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53104] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53105] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53106] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53107] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53108] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53109] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53110] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53111] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53112] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53113] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53114] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53115] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53116] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53117] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53118] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53119] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53120] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53121] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53122] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53123] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53124] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53125] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53126] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53127] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53128] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53129] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53130] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53131] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53132] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53133] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53134] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53135] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53136] = "fixed-version: Fixed from version 6.11.10"
+
+CVE_STATUS[CVE-2024-53137] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53138] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53139] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53140] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53141] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53142] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53143] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53144] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-53145] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53146] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53147] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53148] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53149] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53150] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53151] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53152] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53153] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53154] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53155] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53156] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53157] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53158] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53160] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53161] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53162] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53163] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53164] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53165] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53166] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53167] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53168] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53169] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53170] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53171] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53172] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53173] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53174] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53175] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53176] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53177] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53178] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53179] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53180] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53181] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53182] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53183] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53184] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53185] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53186] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53187] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53188] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53189] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53190] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53191] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53192] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53193] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53194] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53195] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53196] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53197] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53198] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53199] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53200] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53201] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53202] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53203] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53204] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53205] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53206] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53207] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53208] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53209] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53210] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53211] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53212] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53213] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53214] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53215] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53216] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53217] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53218] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53219] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53220] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53221] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53222] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53223] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53224] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53225] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53226] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53227] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53228] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53229] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53230] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53231] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53232] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53233] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53234] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53235] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53236] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53237] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53238] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53239] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53240] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53241] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53680] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53681] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53682] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53685] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53687] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-53690] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-54031] = "fixed-version: Fixed from version 6.12.9"
+
+CVE_STATUS[CVE-2024-54191] = "fixed-version: Fixed from version 6.12.6"
+
+CVE_STATUS[CVE-2024-54193] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-54455] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-54456] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-54458] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-54460] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-54683] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-55639] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-55641] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-55642] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-55881] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-55916] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56368] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56369] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56372] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56531] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56532] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56533] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56534] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56535] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56536] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56537] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56538] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56539] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56540] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56541] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56542] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56543] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56544] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56545] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56546] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56547] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56548] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56549] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56550] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56551] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56552] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56553] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56554] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56555] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56556] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56557] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56558] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56559] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56560] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56561] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56562] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56563] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56564] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56565] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56566] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56567] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56568] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56569] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56570] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56572] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56573] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56574] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56575] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56576] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56577] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56578] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56579] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56580] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56581] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56582] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56583] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56584] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56585] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56586] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56587] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56588] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56589] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56590] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56591] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56592] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56593] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56594] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56595] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56596] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56597] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56598] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56599] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56600] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56601] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56602] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56603] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56604] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56605] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56606] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56607] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56608] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56609] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56610] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56611] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56612] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56613] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56614] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56615] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56616] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56617] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56618] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56619] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56620] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56621] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56622] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56623] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56624] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56625] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56626] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56627] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56628] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56629] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56630] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56631] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56632] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56633] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56634] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56635] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56636] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56637] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56638] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56639] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56640] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56641] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56642] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56643] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56644] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56645] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56646] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56647] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56648] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56649] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56650] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56651] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56652] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56653] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56654] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56655] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56656] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56657] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56658] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56659] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56660] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56661] = "fixed-version: Fixed from version 6.12.6"
+
+CVE_STATUS[CVE-2024-56662] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56663] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56664] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56665] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56666] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56667] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56668] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56669] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56670] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56671] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56672] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56673] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56674] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56675] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56676] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56677] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56678] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56679] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56680] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56681] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56682] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56683] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56684] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56685] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56687] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56688] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56689] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56690] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56691] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56692] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56693] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56694] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56695] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56696] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56697] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56698] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56699] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56700] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56701] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56702] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56703] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56704] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56705] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56706] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56707] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56708] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56709] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56710] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56711] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56712] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56713] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56714] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56715] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56716] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56717] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56718] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56719] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56720] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56721] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56722] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56723] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56724] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56725] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56726] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56727] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56728] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56729] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56730] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56739] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56740] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56742] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56743] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56744] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56745] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56746] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56747] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56748] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56749] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56750] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56751] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56752] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56753] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56754] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56755] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56756] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56757] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56758] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56759] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56760] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56761] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56763] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56764] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56765] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56766] = "fixed-version: Fixed from version 6.12.8"
+
+CVE_STATUS[CVE-2024-56767] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56768] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56769] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56770] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56771] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56772] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56773] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56774] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56775] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56776] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56777] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56778] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56779] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56780] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56781] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56782] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56783] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56784] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56785] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56787] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-56788] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57791] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57792] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57793] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57795] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57798] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57799] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57800] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57801] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57802] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57804] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57805] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57806] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57807] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57809] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57834] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57838] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57839] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57841] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57843] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57844] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57849] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57850] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57852] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57857] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57872] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57874] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57875] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57876] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57877] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57878] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57879] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57880] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57881] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57882] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57883] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57884] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57885] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57886] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57887] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57888] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57889] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57890] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57891] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57892] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57893] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57895] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57896] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57897] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57898] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57899] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57900] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57901] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57902] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57903] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57904] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57905] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57906] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57907] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57908] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57909] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57910] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57911] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57912] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57913] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57914] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57916] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57917] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57918] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57919] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57921] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57922] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57923] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57924] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57925] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57926] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57927] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57928] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57929] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57930] = "fixed-version: Fixed from version 6.12.9"
+
+CVE_STATUS[CVE-2024-57931] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57932] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57933] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57934] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57935] = "fixed-version: Fixed from version 6.12.9"
+
+CVE_STATUS[CVE-2024-57936] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57938] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57939] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57940] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57941] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57942] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57943] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57944] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57945] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57946] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57947] = "fixed-version: Fixed from version 6.11"
+
+CVE_STATUS[CVE-2024-57948] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57949] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57950] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57951] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-57952] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57953] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57973] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57974] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57975] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57976] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57977] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57978] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57979] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57980] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57981] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57982] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57983] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57984] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57985] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57986] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57987] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57988] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57989] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57990] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57991] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57992] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57993] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57994] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57995] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57996] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57997] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57998] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-57999] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58000] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58001] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58002] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58003] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58004] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58005] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58006] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58007] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58008] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58009] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58010] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58011] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58012] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58013] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58014] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58015] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58016] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58017] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58018] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58019] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58020] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58021] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58022] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58034] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58042] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58051] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58052] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58053] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58054] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58055] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58056] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58057] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58058] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58059] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58060] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58061] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58062] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58063] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58064] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58065] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58066] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58067] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58068] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58069] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58070] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58071] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58072] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58073] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58074] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58075] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58076] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58077] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58078] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58079] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58080] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58081] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58082] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58083] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58084] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58085] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58086] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58087] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-58088] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58089] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58090] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58091] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2024-58092] = "fixed-version: Fixed from version 6.14"
+
+# CVE-2024-58093 needs backporting (fixed from 6.15)
+
+CVE_STATUS[CVE-2024-58094] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2024-58095] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2024-58096] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2024-58097] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2024-58098] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-58099] = "fixed-version: Fixed from version 6.12"
+
+CVE_STATUS[CVE-2024-58100] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2024-58237] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21629] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21631] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21632] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21634] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21635] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21636] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21637] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21638] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21639] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21640] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21641] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21642] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21643] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21644] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21645] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21646] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21647] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21648] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21649] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21650] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21651] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21652] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21653] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21654] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21655] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21656] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21657] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21658] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21659] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21660] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21661] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21662] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21663] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21664] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21665] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21666] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21667] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21668] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21669] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21670] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21671] = "fixed-version: Fixed from version 6.12.11"
+
+CVE_STATUS[CVE-2025-21672] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21673] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21674] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21675] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21676] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21677] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21678] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21679] = "fixed-version: Fixed from version 6.12.11"
+
+CVE_STATUS[CVE-2025-21680] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21681] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21682] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21683] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21684] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21685] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21687] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21688] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21689] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21690] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21691] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21692] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21693] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21694] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21695] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21696] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21697] = "fixed-version: Fixed from version 6.13"
+
+CVE_STATUS[CVE-2025-21699] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21700] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21701] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21702] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21703] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21704] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21705] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21706] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21707] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21708] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21709] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21710] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21711] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21712] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21713] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21714] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21715] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21716] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21717] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21718] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21719] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21720] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21721] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21722] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21723] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21724] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21725] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21726] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21727] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21728] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21729] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21730] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21731] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21732] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21733] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21734] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21735] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21736] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21737] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21738] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21739] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21741] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21742] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21743] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21744] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21745] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21746] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21747] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21748] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21749] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21750] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21751] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21752] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21753] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21754] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21756] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21758] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21759] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21760] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21761] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21762] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21763] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21764] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21765] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21766] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21767] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21768] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21769] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21770] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21771] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21772] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21773] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21774] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21775] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21776] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21777] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21778] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21779] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21780] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21781] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21782] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21783] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21784] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21785] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21786] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21787] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21788] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21789] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21790] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21791] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21792] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21793] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21794] = "fixed-version: Fixed from version 6.13.4"
+
+CVE_STATUS[CVE-2025-21795] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21796] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21797] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21798] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21799] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21800] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21801] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21802] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21803] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21804] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21805] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21806] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21807] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21808] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21809] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21810] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21811] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21812] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21813] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21814] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21815] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21816] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21817] = "fixed-version: Fixed from version 6.13.3"
+
+CVE_STATUS[CVE-2025-21819] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21820] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21821] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21822] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21823] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21824] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21825] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21826] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21827] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21828] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21829] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21830] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21831] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21832] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21833] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21834] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21835] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21836] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21838] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21839] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21840] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21841] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21842] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21843] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21844] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21845] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21846] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21847] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21848] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21849] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21850] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21851] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21852] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21853] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21854] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21855] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21856] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21857] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21858] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21859] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21860] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21861] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21862] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21863] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21864] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21865] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21866] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21867] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21868] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21869] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21870] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21871] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21872] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21873] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21874] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21875] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21876] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21877] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21878] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21879] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21880] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21881] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21882] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21883] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21884] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21885] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21886] = "fixed-version: Fixed from version 6.13.6"
+
+CVE_STATUS[CVE-2025-21887] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21888] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21889] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21890] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21891] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21892] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21893] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21894] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21895] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21896] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21897] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21898] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21899] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21900] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21901] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21902] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21903] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21904] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21905] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21906] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21907] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21908] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21909] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21910] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21911] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21912] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21913] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21914] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21915] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21916] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21917] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21918] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21919] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21920] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21921] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21922] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21923] = "fixed-version: Fixed from version 6.13.7"
+
+CVE_STATUS[CVE-2025-21924] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21925] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21926] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21927] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21928] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21929] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21930] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21931] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21932] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21933] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21934] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21935] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21936] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21937] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21938] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21939] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21940] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21941] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21942] = "fixed-version: Fixed from version 6.13.7"
+
+CVE_STATUS[CVE-2025-21943] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21944] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21945] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21946] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21947] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21948] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21949] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21950] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21951] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21952] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21953] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21954] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21955] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21956] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21957] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21958] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21959] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21960] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21961] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21962] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21963] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21964] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21965] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21966] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21967] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21968] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21969] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21970] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21971] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21972] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21973] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21974] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21975] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21976] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21977] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21978] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21979] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21980] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21981] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21982] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21983] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21984] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21985] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21986] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21987] = "fixed-version: Fixed from version 6.14"
+
+# CVE-2025-21988 has no known resolution
+
+CVE_STATUS[CVE-2025-21989] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21990] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21991] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21992] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21993] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21994] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21995] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21996] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21997] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21998] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-21999] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22000] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22001] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22002] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22003] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22004] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22005] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22006] = "fixed-version: Fixed from version 6.13.9"
+
+CVE_STATUS[CVE-2025-22007] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22008] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22009] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22010] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22011] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22012] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22013] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22014] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22015] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22016] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22017] = "fixed-version: Fixed from version 6.14"
+
+CVE_STATUS[CVE-2025-22018] = "cpe-stable-backport: Backported in 6.14.1"
+
+CVE_STATUS[CVE-2025-22019] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22020] = "cpe-stable-backport: Backported in 6.14.1"
+
+CVE_STATUS[CVE-2025-22021] = "cpe-stable-backport: Backported in 6.14.1"
+
+CVE_STATUS[CVE-2025-22022] = "cpe-stable-backport: Backported in 6.14.1"
+
+CVE_STATUS[CVE-2025-22023] = "cpe-stable-backport: Backported in 6.14.1"
+
+CVE_STATUS[CVE-2025-22024] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22025] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22026] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22027] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22028] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22030] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22031] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22032] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22033] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22034] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22035] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22036] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22037] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22038] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22039] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22040] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22041] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22042] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22043] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22044] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22045] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22046] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22047] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22048] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22049] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22050] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22051] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22052] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22053] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22054] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22055] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22056] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22057] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22058] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22059] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22060] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22061] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22062] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22063] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22064] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22065] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22066] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22067] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22068] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22069] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22070] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22071] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22072] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22073] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22074] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22075] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22076] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22077] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-22078] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22079] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22080] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22081] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22082] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22083] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22084] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22085] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22086] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22087] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22088] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22089] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22090] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22091] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22092] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22093] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22094] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22095] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22096] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22097] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22098] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22099] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22100] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22101] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22102] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22103] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22104] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22105] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22106] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22107] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22108] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22109] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22110] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22111] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22112] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22113] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22114] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22115] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22116] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22117] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22118] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22119] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22120] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22121] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22122] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22123] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22124] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22125] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22126] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22127] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-22128] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-23129] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-23130] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-23131] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-23132] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-23133] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-23134] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-23135] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-23136] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-23137] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-23138] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-23140] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23141] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23142] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23143] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23144] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23145] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23146] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23147] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23148] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23149] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23150] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23151] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23152] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23153] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23154] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23155] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23156] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23157] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23158] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23159] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23160] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23161] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23162] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-23163] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37738] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37739] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37740] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37741] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37742] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37743] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37744] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37745] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37746] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37747] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37748] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37749] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37750] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37751] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37752] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37754] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37755] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37756] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37757] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37758] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37759] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37760] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37761] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37762] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37763] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37764] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37765] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37766] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37767] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37768] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37769] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37770] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37771] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37772] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37773] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37774] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37775] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37776] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37777] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37778] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37779] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37780] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37781] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37783] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37784] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37785] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-37786] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37787] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37788] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37789] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37790] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37791] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37792] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37793] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37794] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37796] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37797] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37798] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37799] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37800] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37801] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37802] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37803] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37805] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37806] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37807] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37808] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37809] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37810] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37811] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37812] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37813] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37814] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37815] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37816] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37817] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37818] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37819] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37820] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37821] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37822] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37823] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37824] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37825] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37826] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37827] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37828] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37829] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37830] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37831] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37833] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37834] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37836] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37837] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37838] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37839] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37840] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37841] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37842] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37843] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37844] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37845] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37846] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37847] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37848] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37849] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37850] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37851] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37852] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37853] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37854] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37855] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37856] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37857] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37858] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37859] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37860] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-37861] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37862] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37863] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37864] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37865] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37866] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37867] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37868] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37869] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37870] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37871] = "fixed-version: Fixed from version 6.14.4"
+
+CVE_STATUS[CVE-2025-37872] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37873] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37874] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37875] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37876] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37877] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37878] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37879] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37880] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37881] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37882] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37883] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37884] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37885] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37886] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37887] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37888] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37889] = "fixed-version: Fixed from version 6.14"
+
+# CVE-2025-37890 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37891 may need backporting (fixed from 6.14.6)
+
+CVE_STATUS[CVE-2025-37892] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37893] = "cpe-stable-backport: Backported in 6.14.2"
+
+# CVE-2025-37894 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37895 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37896 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37897 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37898 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37899 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37900 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37901 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37903 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37904 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37905 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37906 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37907 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37908 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37909 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37910 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37911 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37912 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37913 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37914 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37915 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37916 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37917 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37918 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37919 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37920 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37921 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37922 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37923 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37924 may need backporting (fixed from 6.14.6)
+
+CVE_STATUS[CVE-2025-37925] = "cpe-stable-backport: Backported in 6.14.2"
+
+# CVE-2025-37926 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37927 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37928 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37929 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37930 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37931 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37932 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37933 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37934 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37935 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37936 may need backporting (fixed from 6.14.6)
+
+CVE_STATUS[CVE-2025-37937] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-37938] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-37939] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-37940] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37941] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37942] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37943] = "cpe-stable-backport: Backported in 6.14.3"
+
+CVE_STATUS[CVE-2025-37944] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37945] = "cpe-stable-backport: Backported in 6.14.3"
+
+# CVE-2025-37946 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37947 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37948 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37949 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37950 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37951 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37952 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37953 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37954 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37955 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37956 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37957 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37958 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37959 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37960 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37961 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37962 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37963 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37964 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37965 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37966 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37967 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37968 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37969 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37970 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37971 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37972 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37973 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37974 may need backporting (fixed from 6.14.7)
+
+CVE_STATUS[CVE-2025-37975] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37977] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37978] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37979] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37980] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37981] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37982] = "cpe-stable-backport: Backported in 6.14.4"
+
+CVE_STATUS[CVE-2025-37983] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37984] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37985] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37986] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37987] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37988] = "cpe-stable-backport: Backported in 6.14.5"
+
+CVE_STATUS[CVE-2025-37989] = "cpe-stable-backport: Backported in 6.14.5"
+
+# CVE-2025-37990 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37991 may need backporting (fixed from 6.14.6)
+
+# CVE-2025-37992 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-37993 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37994 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37995 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37996 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37997 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37998 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-37999 may need backporting (fixed from 6.14.7)
+
+# CVE-2025-38000 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38001 may need backporting (fixed from 6.14.10)
+
+# CVE-2025-38002 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38003 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38004 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38005 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38006 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38007 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38008 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38009 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38010 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38011 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38012 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38013 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38014 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38015 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38016 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38017 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38018 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38019 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38020 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38021 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38022 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38023 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38024 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38025 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38027 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38028 may need backporting (fixed from 6.14.8)
+
+# CVE-2025-38029 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38031 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38032 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38033 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38034 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38035 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38036 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38037 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38038 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38039 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38040 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38041 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38042 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38043 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38044 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38045 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38047 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38048 may need backporting (fixed from 6.14.9)
+
+CVE_STATUS[CVE-2025-38049] = "cpe-stable-backport: Backported in 6.14.2"
+
+# CVE-2025-38050 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38051 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38052 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38053 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38054 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38055 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38056 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38057 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38058 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38059 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38060 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38061 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38062 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38063 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38064 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38065 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38066 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38067 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38068 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38069 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38070 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38071 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38072 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38073 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38074 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38075 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38076 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38077 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38078 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38079 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38080 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38081 may need backporting (fixed from 6.14.9)
+
+# CVE-2025-38082 may need backporting (fixed from 6.14.10)
+
+# CVE-2025-38083 needs backporting (fixed from 6.16rc2)
+
+CVE_STATUS[CVE-2025-38104] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-38152] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-38240] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-38479] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-38575] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-38637] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-39688] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-39728] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-39735] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-39755] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-39778] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-39930] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-39989] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-40014] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-40114] = "cpe-stable-backport: Backported in 6.14.2"
+
+CVE_STATUS[CVE-2025-40325] = "cpe-stable-backport: Backported in 6.14.2"
+
+# CVE-2025-40364 has no known resolution
+

--- a/recipes-kernel/linux/linux-skov.bb
+++ b/recipes-kernel/linux/linux-skov.bb
@@ -22,6 +22,7 @@ SRC_URI += "file://defconfig"
 require linux-skov/patches/series.inc
 # Patches not yet folded into the Pengutronix patch stack
 require linux-skov/patches-skov/series.inc
+include recipes-kernel/linux/cve-exclusion.inc
 
 S = "${WORKDIR}/linux-${LINUX_VERSION}"
 


### PR DESCRIPTION
Done by running
       generate-cve-exclusions.py linux_kernel_cves 6.14.5

