### PR TITLE
linux-skov: fix support for JuTouch 10" panels

### DIFF
--- a/recipes-kernel/linux/linux-skov/patches/0821-arm64-dts-imx8mp-skov-support-new-10-panel-board.patch
+++ b/recipes-kernel/linux/linux-skov/patches/0821-arm64-dts-imx8mp-skov-support-new-10-panel-board.patch
@@ -23,7 +23,7 @@ index 986c4f974da5..17c2124370c7 100644
  dtb-$(CONFIG_ARCH_MXC) += imx8mp-var-som-symphony.dtb
 diff --git a/arch/arm64/boot/dts/freescale/imx8mp-skov-revc-jutouch-jt101tm023.dts b/arch/arm64/boot/dts/freescale/imx8mp-skov-revc-jutouch-jt101tm023.dts
 new file mode 100644
-index 000000000000..3b239bbe2b53
+index 000000000000..676c604fb4e5
 --- /dev/null
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-skov-revc-jutouch-jt101tm023.dts
 @@ -0,0 +1,79 @@
@@ -79,8 +79,8 @@ index 000000000000..3b239bbe2b53
 +	assigned-clocks = <&clk IMX8MP_CLK_MEDIA_LDB>,
 +				 <&clk IMX8MP_VIDEO_PLL1>;
 +	assigned-clock-parents = <&clk IMX8MP_VIDEO_PLL1_OUT>;
-+	/* IMX8MP_VIDEO_PLL1 = IMX8MP_CLK_MEDIA_DISP2_PIX * 2 * 7 */
-+	assigned-clock-rates = <0>, <980000000>;
++	/* IMX8MP_VIDEO_PLL1 = IMX8MP_CLK_MEDIA_DISP2_PIX * 7 */
++	assigned-clock-rates = <0>, <506800000>;
 +	status = "okay";
 +
 +	ports {

--- a/recipes-kernel/linux/linux-skov/patches/1601-Release-6.14-customers-skov-imx6-20250722-1.patch
+++ b/recipes-kernel/linux/linux-skov/patches/1601-Release-6.14-customers-skov-imx6-20250722-1.patch
@@ -1,13 +1,13 @@
 From: Steffen Trumtrar <s.trumtrar@pengutronix.de>
-Date: Fri, 27 Jun 2025 11:59:39 +0200
-Subject: [PATCH] Release 6.14/customers/skov/imx6/20250627-1
+Date: Tue, 22 Jul 2025 13:47:43 +0200
+Subject: [PATCH] Release 6.14/customers/skov/imx6/20250722-1
 
 ---
  Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 48d2ce96398b..2e7f773aa8a3 100644
+index 48d2ce96398b..46bcecbd26bb 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -2,7 +2,7 @@
@@ -15,7 +15,7 @@ index 48d2ce96398b..2e7f773aa8a3 100644
  PATCHLEVEL = 14
  SUBLEVEL = 11
 -EXTRAVERSION =
-+EXTRAVERSION =-20250627-1
++EXTRAVERSION =-20250722-1
  NAME = Baby Opossum Posse
  
  # *DOCUMENTATION*

--- a/recipes-kernel/linux/linux-skov/patches/series.inc
+++ b/recipes-kernel/linux/linux-skov/patches/series.inc
@@ -1,24 +1,24 @@
 # umpf-base: v6.14.11
 # umpf-name: 6.14/customers/skov/imx6
-# umpf-version: 6.14/customers/skov/imx6/20250627-1
+# umpf-version: 6.14/customers/skov/imx6/20250722-1
 # umpf-topic: v6.12/topic/drm-sched-accounting
 # umpf-hashinfo: a886925c1b1aedf839db4297e1b6a8e87e01b63d
 # umpf-topic-range: b9d5d463c216763cec719c04536ea9e14512cad4..a522d517242f4bf26bcfb8b64f179ffce4d108af
-SRC_URI += "\
+UMPF_SRC_URI += "\
   file://patches/0001-drm-sched-add-sysfs-stats-output.patch \
   file://patches/0002-drm-sched-track-execution-time-per-scheduler.patch \
   "
 # umpf-topic: v6.13/topic/dw-hdmi
 # umpf-hashinfo: 09b091ba6cd0fefa5356eb4afb0cd2aff05cb345
 # umpf-topic-range: a522d517242f4bf26bcfb8b64f179ffce4d108af..b35759ca5e6c87b89665d40ebac89bd70517face
-SRC_URI += "\
+UMPF_SRC_URI += "\
   file://patches/0101-drm-bridge-dw_hdmi-detect-initial-connector-state.patch \
   file://patches/0102-drm-bridge-dw_hdmi-use-rx-sense-for-plug-detection-i.patch \
   "
 # umpf-topic: v6.13/topic/etnaviv
 # umpf-hashinfo: 021830299d7ebc2b6dc3a670e6fe9535d2b7898d
 # umpf-topic-range: b35759ca5e6c87b89665d40ebac89bd70517face..ea350cea4046426241f28895799fb8f777a19743
-SRC_URI += "\
+UMPF_SRC_URI += "\
   file://patches/0201-drm-etnaviv-add-flight-recorder-mode.patch \
   file://patches/0202-drm-etnaviv-reset-bit-0-when-disabling-pulse-eater-f.patch \
   file://patches/0203-drm-etnaviv-disable-pulse-eater-on-cores-with-3D-pip.patch \
@@ -27,20 +27,20 @@ SRC_URI += "\
 # umpf-topic: v6.13/topic/imx-drm
 # umpf-hashinfo: e52c347d736db54c09f72e01f536bb0db025be6c
 # umpf-topic-range: ea350cea4046426241f28895799fb8f777a19743..ef10ecbd252b38356a35b199e3dd7fa30526b987
-SRC_URI += "\
+UMPF_SRC_URI += "\
   file://patches/0301-drm-imx-ipuv3-plane-add-debug-output.patch \
   file://patches/0302-gpu-ipu-v3-ipu-dc-setup-microcode-from-u64-array.patch \
   "
 # umpf-topic: v6.13/topic/imx-gpc
 # umpf-hashinfo: ede209c646be26a36f17647e6fd82d8fe7f85057
 # umpf-topic-range: ef10ecbd252b38356a35b199e3dd7fa30526b987..0b38e65291e3ad060f6f6b32bec47707dde1badc
-SRC_URI += "\
+UMPF_SRC_URI += "\
   file://patches/0401-soc-imx-gpc-set-DMA-mask-for-PD-platform-devices.patch \
   "
 # umpf-topic: v6.14/topic/imx-gpcv2
 # umpf-hashinfo: fb8175864f1faaeaf2afd0059ee7cebb5a7105f8
 # umpf-topic-range: 0b38e65291e3ad060f6f6b32bec47707dde1badc..52ea484b011e3eb71549689c803a4d61a54fc292
-SRC_URI += "\
+UMPF_SRC_URI += "\
   file://patches/0501-pmdomain-imx-gpcv2-split-PGC-domain-probe-in-two-pas.patch \
   file://patches/0502-pmdomain-imx-gpcv2-rename-keep_clocks-to-bus_clocks.patch \
   file://patches/0503-pmdomain-imx-gpcv2-prepare-bus-clocks-early.patch \
@@ -48,14 +48,14 @@ SRC_URI += "\
 # umpf-topic: v6.14/topic/imx8mp-dt
 # umpf-hashinfo: 957ee615df4cfc68ba7593db23b2ccdf466b1c05
 # umpf-topic-range: 52ea484b011e3eb71549689c803a4d61a54fc292..7ee1ff0f8e3ff4328846fcb2bd6415a5b1987c84
-SRC_URI += "\
+UMPF_SRC_URI += "\
   file://patches/0601-arm64-dts-imx8mp-add-interconnect-for-lcdif-hdmi.patch \
   file://patches/0602-HACK-arm64-dts-imx8mp-Hook-up-MLMIX-reset-to-power-d.patch \
   "
 # umpf-topic: v6.14/topic/imx8mp-nominal
 # umpf-hashinfo: 7027e3a67027dc587ddd5259ef6f6cb9fdc846e8
 # umpf-topic-range: 7ee1ff0f8e3ff4328846fcb2bd6415a5b1987c84..9992121369fd8f6c6ce5fd4842042fc8dbc213eb
-SRC_URI += "\
+UMPF_SRC_URI += "\
   file://patches/0701-dt-bindings-clock-imx8m-document-nominal-overdrive-p.patch \
   file://patches/0702-arm64-dts-imx8mp-Add-optional-nominal-drive-mode-DTS.patch \
   file://patches/0703-arm64-dts-imx8mp-add-fsl-nominal-mode-property-into-.patch \
@@ -63,9 +63,9 @@ SRC_URI += "\
   file://patches/0705-arm64-dts-freescale-imx8mp-skov-operate-SoC-in-nomin.patch \
   "
 # umpf-topic: v6.14/topic/imx8mp-skov-dts
-# umpf-hashinfo: f2a3511e4b74b1266e5209d579fee5f495c13dd6
-# umpf-topic-range: 9992121369fd8f6c6ce5fd4842042fc8dbc213eb..be9129f641831864c1c2019ce9e8275c1b780a1d
-SRC_URI += "\
+# umpf-hashinfo: e96bf58df53a1d1a21b874db20d7207643664be5
+# umpf-topic-range: 9992121369fd8f6c6ce5fd4842042fc8dbc213eb..97fe030e376c7cc1ce16647a67a8a38291487572
+UMPF_SRC_URI += "\
   file://patches/0801-arm64-dts-imx8mp-skov-use-I2C5-for-DDC.patch \
   file://patches/0802-arm64-dts-imx8mp-skov-describe-HDMI-display-pipeline.patch \
   file://patches/0803-dt-bindings-display-lvds-codec-add-ti-sn65lvds822.patch \
@@ -92,14 +92,14 @@ SRC_URI += "\
   "
 # umpf-topic: v6.8/topic/drm-fsl-ldb
 # umpf-hashinfo: 8b41dc23a7e169047e05bd485563734d3396038f
-# umpf-topic-range: be9129f641831864c1c2019ce9e8275c1b780a1d..81b7e01879ebe6c661da800d5fc5756653c65d9a
-SRC_URI += "\
+# umpf-topic-range: 97fe030e376c7cc1ce16647a67a8a38291487572..50331c02ae04bef78c5f9092d09b61a318ddc5b1
+UMPF_SRC_URI += "\
   file://patches/0901-drm-bridge-fsl-ldb-Fix-EPROBE_DEFER-error-on-bridge-.patch \
   "
 # umpf-topic: v6.14/topic/hw_protection
 # umpf-hashinfo: 62041d9dfc4d156556c209cd6109e75421d7bfcf
-# umpf-topic-range: 81b7e01879ebe6c661da800d5fc5756653c65d9a..a9bb8ddfd7e71eefb9ac5650ef62b02220b9bcf4
-SRC_URI += "\
+# umpf-topic-range: 50331c02ae04bef78c5f9092d09b61a318ddc5b1..aa43d8a383862795633c690d960ef991c9454712
+UMPF_SRC_URI += "\
   file://patches/1001-docs-thermal-sync-hardware-protection-doc-with-code.patch \
   file://patches/1002-reboot-describe-do_kernel_restart-s-cmd-argument-in-.patch \
   file://patches/1003-reboot-rename-now-misleading-__hw_protection_shutdow.patch \
@@ -113,8 +113,8 @@ SRC_URI += "\
   "
 # umpf-topic: v6.14/topic/regulator-mmc-under-voltage
 # umpf-hashinfo: 87f91a081ae53360efcef3063b505a8eabbec5b2
-# umpf-topic-range: a9bb8ddfd7e71eefb9ac5650ef62b02220b9bcf4..56beb8ffcea6b1bc234e27dc190ba15cfcd22233
-SRC_URI += "\
+# umpf-topic-range: aa43d8a383862795633c690d960ef991c9454712..6a0a50c16c62ea8bba47c22a59f8654251edfd16
+UMPF_SRC_URI += "\
   file://patches/1101-WIP-mmc-core-shut-down-storage-as-early-as-possible.patch \
   file://patches/1102-power-Extend-power_on_reason.h-for-upcoming-PSCRR-fr.patch \
   file://patches/1103-dt-bindings-power-reset-add-generic-PSCRR-binding-tr.patch \
@@ -127,37 +127,39 @@ SRC_URI += "\
   "
 # umpf-topic: v6.8/topic/gic-v3-its
 # umpf-hashinfo: fdae192fa61f6e8b20131c838fd1b85f807ab60d
-# umpf-topic-range: 56beb8ffcea6b1bc234e27dc190ba15cfcd22233..f120ab098652e334648f99b2a2456fc7d253b7b1
-SRC_URI += "\
+# umpf-topic-range: 6a0a50c16c62ea8bba47c22a59f8654251edfd16..73a543ec534e149d5e3def43610d724bf6ecec08
+UMPF_SRC_URI += "\
   file://patches/1201-irqchip-gic-v3-its-Degrade-warning-when-no-ITS-avail.patch \
   "
 # umpf-topic: v6.14/topic/pca9450
 # umpf-hashinfo: faa472d8da2ede80fb4083c357119270a3615f22
-# umpf-topic-range: f120ab098652e334648f99b2a2456fc7d253b7b1..b1a926114fee0ecddcf640c7472d5e264059760a
-SRC_URI += "\
+# umpf-topic-range: 73a543ec534e149d5e3def43610d724bf6ecec08..65999fc87eb4c80c50952ab38e6b90f9c82debc7
+UMPF_SRC_URI += "\
   file://patches/1301-regulator-pca9450-introduce-system-restart-handler.patch \
   file://patches/1302-regulator-dt-bindings-pca9450-add-restart-handler-pr.patch \
   file://patches/1303-WIP-regulator-pca9450-add-vin-supply-DT-support.patch \
   "
 # umpf-topic: v6.14/topic/rtc-pcf85063
 # umpf-hashinfo: 3cc474c7cd4f3c32229f30ec39e9bbbe627e33fb
-# umpf-topic-range: b1a926114fee0ecddcf640c7472d5e264059760a..225cdd424af06863d12046b282d2219efda3bf42
-SRC_URI += "\
+# umpf-topic-range: 65999fc87eb4c80c50952ab38e6b90f9c82debc7..cc8d32051710aab73b16f5d583da3198331ea218
+UMPF_SRC_URI += "\
   file://patches/1401-rtc-pcf85063-ensure-12-hour-mode-is-disabled.patch \
   "
 # umpf-topic: v6.14/topic/imx-gpio-base-warning
 # umpf-hashinfo: 773cf25f8d2da5bc69df651e76c4442a00fd4dab
-# umpf-topic-range: 225cdd424af06863d12046b282d2219efda3bf42..6c5f9f4dc028b3f28c23cddea2c65b0b4834b1cb
-SRC_URI += "\
+# umpf-topic-range: cc8d32051710aab73b16f5d583da3198331ea218..9065a6ba38590f504557ce0b6f1ffa95222b3e0d
+UMPF_SRC_URI += "\
   file://patches/1501-gpio-mxc-configure-dynamic-GPIO-base-for-CONFIG_GPIO.patch \
   "
-# umpf-release: 6.14/customers/skov/imx6/20250627-1
-# umpf-topic-range: 6c5f9f4dc028b3f28c23cddea2c65b0b4834b1cb..e361f9bb456be019abd1b885770eded59664fe97
-SRC_URI += "\
-  file://patches/1601-Release-6.14-customers-skov-imx6-20250627-1.patch \
+# umpf-release: 6.14/customers/skov/imx6/20250722-1
+# umpf-topic-range: 9065a6ba38590f504557ce0b6f1ffa95222b3e0d..24e32b66e21145e5743babef2b92db42103471ec
+UMPF_SRC_URI += "\
+  file://patches/1601-Release-6.14-customers-skov-imx6-20250722-1.patch \
   "
+SRC_URI += "${UMPF_SRC_URI}"
+
 UMPF_BASE = "6.14.11"
-UMPF_VERSION = "20250627-1"
+UMPF_VERSION = "20250722-1"
 UMPF_PV = "${UMPF_BASE}-${UMPF_VERSION}"
-LINUX_VERSION = "${UMPF_BASE}"
+LINUX_VERSION ?= "${UMPF_BASE}"
 # umpf-end


### PR DESCRIPTION
The LVDS clock is set to the wrong rate and the clocktree can't therefore find the correct settings and fails.

Fix that and correct the comment, that the pixelclock should actually be 7 times the display clock *not* 14 times.