### PR TITLE
Clean up /boot on the imx8s-cpu

### DIFF
--- a/conf/machine/imx8s-cpu.conf
+++ b/conf/machine/imx8s-cpu.conf
@@ -11,8 +11,14 @@ require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 MACHINE_FEATURES = "usbgadget usbhost vfat touchscreen serial rtc habv4"
 MACHINE_EXTRA_RRECOMMENDS = " \
     kernel-modules \
-    kernel-devicetree \
 "
+
+# Inactivate the recommendation weakly set in poky's kernel.bbclass [1] to get
+# rid of kernel images in the root-FS (/boot/*Image*) as they are separately
+# stored via FIT-images in dedicated partitions.
+#
+# [1] https://git.yoctoproject.org/poky/tree/meta/classes-recipe/kernel.bbclass?h=mickledore-4.2.3&id=aa63b25cbe25#n681
+BAD_RECOMMENDATIONS = "kernel-image-*"
 
 MACHINE_SOCARCH = "${TUNE_PKGARCH}-mx8mp"
 MACHINE_ARCH_FILTER = "virtual/kernel"


### PR DESCRIPTION
This pull request should only be merged after that [one](https://github.com/SKOV-DK/skov-sdk/pull/275) for ``skov-sdk``. If both are finally merged than ``/boot`` will not contain kernel and devicetrees anymore on the ``imx8s-cpu``, but only for the ``imx6-cpu`` and the ``imx8-cpu``. It emerged as a side-effect from my current work on OP-TEE integration.