### PR TITLE
Do not Start "platsch" as PID1 on Headless Systems

### DIFF
--- a/recipes-bsp/barebox/files/imx8s-cpu/env/boot/failsafe
+++ b/recipes-bsp/barebox/files/imx8s-cpu/env/boot/failsafe
@@ -5,4 +5,7 @@ global bootm.root_dev=mmc2.failsafe
 global bootm.image=/dev/mmc2.failsafe.fit
 global linux.bootargs.dyn.rootwait=rootwait
 
-global linux.bootargs.dyn.bootentries="init=/usr/sbin/platsch fsck.repair=yes usbcore.autosuspend=-1 hw_protection=reboot"
+global linux.bootargs.dyn.bootentries="fsck.repair=yes usbcore.autosuspend=-1 hw_protection=reboot"
+if [ ${global.hostname} != "imx8mp-skov-revc-bd500" ]; then
+    global linux.bootargs.dyn.init_platsch="init=/usr/sbin/platsch"
+fi

--- a/recipes-bsp/barebox/files/imx8s-cpu/env/boot/sd
+++ b/recipes-bsp/barebox/files/imx8s-cpu/env/boot/sd
@@ -6,6 +6,9 @@ global bootm.image=/dev/mmc1.system.fit
 global linux.bootargs.dyn.rootwait=rootwait
 global linux.bootargs.dyn.rauc=rauc.external
 
-global linux.bootargs.dyn.bootentries="init=/usr/sbin/platsch fsck.repair=yes usbcore.autosuspend=-1 hw_protection=reboot net.ifnames=0"
+global linux.bootargs.dyn.bootentries="fsck.repair=yes usbcore.autosuspend=-1 hw_protection=reboot net.ifnames=0"
+if [ ${global.hostname} != "imx8mp-skov-revc-bd500" ]; then
+    global linux.bootargs.dyn.init_platsch="init=/usr/sbin/platsch"
+fi
 
 detect mmc1

--- a/recipes-bsp/barebox/files/imx8s-cpu/env/boot/system0
+++ b/recipes-bsp/barebox/files/imx8s-cpu/env/boot/system0
@@ -5,4 +5,7 @@ global bootm.root_dev=mmc2.system0
 global bootm.image=/dev/mmc2.system0.fit
 global linux.bootargs.dyn.rootwait=rootwait
 
-global linux.bootargs.dyn.bootentries="init=/usr/sbin/platsch fsck.repair=yes usbcore.autosuspend=-1 hw_protection=reboot net.ifnames=0"
+global linux.bootargs.dyn.bootentries="fsck.repair=yes usbcore.autosuspend=-1 hw_protection=reboot net.ifnames=0"
+if [ ${global.hostname} != "imx8mp-skov-revc-bd500" ]; then
+    global linux.bootargs.dyn.init_platsch="init=/usr/sbin/platsch"
+fi

--- a/recipes-bsp/barebox/files/imx8s-cpu/env/boot/system1
+++ b/recipes-bsp/barebox/files/imx8s-cpu/env/boot/system1
@@ -5,4 +5,7 @@ global bootm.root_dev=mmc2.system1
 global bootm.image=/dev/mmc2.system1.fit
 global linux.bootargs.dyn.rootwait=rootwait
 
-global linux.bootargs.dyn.bootentries="init=/usr/sbin/platsch fsck.repair=yes usbcore.autosuspend=-1 hw_protection=reboot net.ifnames=0"
+global linux.bootargs.dyn.bootentries="fsck.repair=yes usbcore.autosuspend=-1 hw_protection=reboot net.ifnames=0"
+if [ ${global.hostname} != "imx8mp-skov-revc-bd500" ]; then
+    global linux.bootargs.dyn.init_platsch="init=/usr/sbin/platsch"
+fi


### PR DESCRIPTION
Big Dutchman's ``bd500`` variant of the ``IMX8`` board (board 2, rev c, compatible ``imx8mp-skov-revc-bd500``) doesn't have the DRM-devices required by _platsch_ so that _platsch_ exits with an error condition as a result. Since it is started as PID1 this leads to a kernel panic. There is no need for a splash screen on a headless system so just start the default in that case (``init=/usr/sbin/init`` which is a symbolic link to ``/usr/lib/systemd/systemd``).