### PR TITLE
Add Display Resolution to Kernel Commandline for IMX8

### DIFF
--- a/recipes-bsp/barebox/files/imx8-cpu/env/env.inc
+++ b/recipes-bsp/barebox/files/imx8-cpu/env/env.inc
@@ -20,10 +20,11 @@ SRC_URI += "\
   file://env/nv/bootchooser.targets \
   file://env/nv/bootchooser.system0.boot \
   file://env/nv/bootchooser.system1.boot \
+  file://env/boot/failsafe \
+  file://env/boot/sd \
   file://env/boot/system0 \
   file://env/boot/system1 \
   file://env/init/bootargs \
-  file://env/boot/failsafe \
-  file://env/boot/sd \
+  file://env/init/display \
   "
 

--- a/recipes-bsp/barebox/files/imx8-cpu/env/init/display
+++ b/recipes-bsp/barebox/files/imx8-cpu/env/init/display
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+DISPLAY=""
+if [ ! ${state.display.xres} -eq 0 ]; then
+        DISPLAY="$DISPLAY display.xres=${state.display.xres}"
+fi
+if [ ! ${state.display.yres} -eq 0 ]; then
+        DISPLAY="$DISPLAY display.yres=${state.display.yres}"
+fi
+if [ ! ${state.display.external} -eq 0 ]; then
+        DISPLAY="$DISPLAY display.external=${state.display.external}"
+fi
+
+global linux.bootargs.display="$DISPLAY"

--- a/recipes-bsp/barebox/files/imx8s-cpu/env/env.inc
+++ b/recipes-bsp/barebox/files/imx8s-cpu/env/env.inc
@@ -25,5 +25,6 @@ SRC_URI += "\
   file://env/boot/system0 \
   file://env/boot/system1 \
   file://env/init/bootargs \
+  file://env/init/display \
   "
 

--- a/recipes-bsp/barebox/files/imx8s-cpu/env/init/display
+++ b/recipes-bsp/barebox/files/imx8s-cpu/env/init/display
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+DISPLAY=""
+if [ ! ${state.display.xres} -eq 0 ]; then
+        DISPLAY="$DISPLAY display.xres=${state.display.xres}"
+fi
+if [ ! ${state.display.yres} -eq 0 ]; then
+        DISPLAY="$DISPLAY display.yres=${state.display.yres}"
+fi
+if [ ! ${state.display.external} -eq 0 ]; then
+        DISPLAY="$DISPLAY display.external=${state.display.external}"
+fi
+
+global linux.bootargs.display="$DISPLAY"


### PR DESCRIPTION
It was missing on the ``imx8-cpu`` as well as on the ``imx8s-cpu`` since the early days.

**Note:** Currently in Linux userspace ``barebox-state`` is utilized to nevertheless get the required data. Although this works it introduces a latency of approximately 0.14s (probably multiple times) which is not a little but in the order of the results achieved during boot time optimization. So it is worth a look if parsing from the kernel commandline is again the better option after the merge of this pull request.