### PR TITLE
Reject RAUC-Bundles with the Deprecated "plain" Format

### DIFF
--- a/recipes-core/rauc/rauc/imx6-cpu/system.conf.in
+++ b/recipes-core/rauc/rauc/imx6-cpu/system.conf.in
@@ -6,6 +6,7 @@ bootloader=barebox
 mountprefix=/run/rauc
 data-directory=@RAUC_DATA_DIR@
 statusfile=@RAUC_DATA_DIR@/system.raucs
+bundle-formats=-plain
 
 [keyring]
 path=@RAUC_KEYRING_FILE@

--- a/recipes-core/rauc/rauc/imx8-cpu/system.conf.in
+++ b/recipes-core/rauc/rauc/imx8-cpu/system.conf.in
@@ -6,6 +6,7 @@ bootloader=barebox
 mountprefix=/run/rauc
 data-directory=@RAUC_DATA_DIR@
 statusfile=@RAUC_DATA_DIR@/system.raucs
+bundle-formats=-plain
 
 [keyring]
 path=@RAUC_KEYRING_FILE@

--- a/recipes-core/rauc/rauc/imx8s-cpu/system.conf.in
+++ b/recipes-core/rauc/rauc/imx8s-cpu/system.conf.in
@@ -6,6 +6,7 @@ bootloader=barebox
 mountprefix=/run/rauc
 data-directory=@RAUC_DATA_DIR@
 statusfile=@RAUC_DATA_DIR@/system.raucs
+bundle-formats=-plain
 
 [keyring]
 path=@RAUC_KEYRING_FILE@


### PR DESCRIPTION
The option to allow only the preferred ``verity`` format has existed since late 2020, and this project stopped creating bundles in the outdated ``plain`` format at the end of 2022. Now, finally, allow only the recommended ``verity`` format to complete this migration. See [here](https://github.com/rauc/meta-rauc/commit/a23c119dff63678810cb43aa43efa579068b68b8), [here](https://rauc.readthedocs.io/en/latest/reference.html#sec-ref-formats) and [here](https://rauc.readthedocs.io/en/latest/integration.html#bundle-format-migration) for details.