### PR TITLE
Update barebox to 2025.06.1-20260619-1

### DIFF
--- a/recipes-bsp/barebox/files/patches/0002-ARM-boards-skov-imx6-fix-device-tree-path-of-state-n.patch
+++ b/recipes-bsp/barebox/files/patches/0002-ARM-boards-skov-imx6-fix-device-tree-path-of-state-n.patch
@@ -1,0 +1,38 @@
+From: =?UTF-8?q?Ulrich=20=C3=96lmann?= <u.oelmann@pengutronix.de>
+Date: Fri, 19 Jun 2026 14:47:03 +0200
+Subject: [PATCH] ARM: boards: skov-imx6: fix device tree path of state node
+
+The reference broke in commit [1] and led to the following error message during
+boot while fixing up the kernel devicetree:
+
+  Loading ARM Linux zImage '/mnt/nand0.firmware.ubi.system0//boot/zImage'
+  Loading devicetree from '/mnt/nand0.firmware.ubi.system0//boot/imx6dl-skov-revc-lt2.dtb'
+  ERROR: skov-imx6 machine: Node /state/ethaddr/eth2 defining the state variable not found.
+
+[1] c00df6a4b552 ("ARM: dts: Fix dtc warnings in state nodes")
+---
+ arch/arm/boards/skov-imx6/board.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/boards/skov-imx6/board.c b/arch/arm/boards/skov-imx6/board.c
+index 164833568ab9..8c837b8a8fb9 100644
+--- a/arch/arm/boards/skov-imx6/board.c
++++ b/arch/arm/boards/skov-imx6/board.c
+@@ -384,7 +384,7 @@ static int skov_imx6_switch_port(struct device_node *root, const char *path)
+ 
+ 	ret = eth2_of_fixup_node_individually(root, buf, "eth0",
+ 					      "state.ethaddr.eth2",
+-					      "/state/ethaddr/eth2");
++					      "/state/ethaddr/eth2@1e");
+ 	return ret;
+ }
+ 
+@@ -563,7 +563,7 @@ static void skov_init_board(const struct board_description *variant)
+ 
+ static int skov_set_switch_lan2_mac(struct skov_imx6_priv *priv)
+ {
+-	const char *state = "/state/ethaddr/eth2";
++	const char *state = "/state/ethaddr/eth2@1e";
+ 	struct device_node *lan2_np;
+ 	u8 ethaddr[ETH_ALEN];
+ 	int ret;

--- a/recipes-bsp/barebox/files/patches/0601-Release-2025.06.1-customers-skov-imx6-20260619-1.patch
+++ b/recipes-bsp/barebox/files/patches/0601-Release-2025.06.1-customers-skov-imx6-20260619-1.patch
@@ -1,13 +1,13 @@
 From: =?UTF-8?q?Ulrich=20=C3=96lmann?= <u.oelmann@pengutronix.de>
-Date: Wed, 26 Nov 2025 14:56:00 +0100
-Subject: [PATCH] Release 2025.06.1/customers/skov/imx6/20251126-1
+Date: Fri, 19 Jun 2026 15:23:19 +0200
+Subject: [PATCH] Release 2025.06.1/customers/skov/imx6/20260619-1
 
 ---
  Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 2aa1762ac454..1578639405ad 100644
+index 2aa1762ac454..f939becf7121 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -2,7 +2,7 @@
@@ -15,7 +15,7 @@ index 2aa1762ac454..1578639405ad 100644
  PATCHLEVEL = 06
  SUBLEVEL = 1
 -EXTRAVERSION =
-+EXTRAVERSION =-20251126-1
++EXTRAVERSION =-20260619-1
  NAME = None
  
  # *DOCUMENTATION*

--- a/recipes-bsp/barebox/files/patches/series.inc
+++ b/recipes-bsp/barebox/files/patches/series.inc
@@ -1,15 +1,16 @@
 # umpf-base: v2025.06.1
 # umpf-name: 2025.06.1/customers/skov/imx6
-# umpf-version: 2025.06.1/customers/skov/imx6/20251126-1
+# umpf-version: 2025.06.1/customers/skov/imx6/20260619-1
 # umpf-topic: v2025.02.0/customers/skov/imx6
-# umpf-hashinfo: a5e36061c79278440238800873474f1a72538f0e
-# umpf-topic-range: 7e5ea8eb09a1ca3b13e89586411f5a60ae8fd5b3..c9f1f50e5a2bc34ea178939fa48e577dea5fd642
+# umpf-hashinfo: 455885ffe06014703bfa4394caf5d7e9a3cef32e
+# umpf-topic-range: 7e5ea8eb09a1ca3b13e89586411f5a60ae8fd5b3..c4442005dcfc329a7a95857896a39e62ab3a47af
 UMPF_SRC_URI += "\
   file://patches/0001-video-edid-increase-number-of-retries-to-request-EDI.patch \
+  file://patches/0002-ARM-boards-skov-imx6-fix-device-tree-path-of-state-n.patch \
   "
 # umpf-topic: v2025.06.0/customers/skov/imx8mp
 # umpf-hashinfo: 263ef246e22d635e4d4045f5de5cf3a6fbeb7dec
-# umpf-topic-range: c9f1f50e5a2bc34ea178939fa48e577dea5fd642..4d0e135569ea91805a8e768afc3f0fe99c9d44bb
+# umpf-topic-range: c4442005dcfc329a7a95857896a39e62ab3a47af..7e222e120f539b892eefea4e2cbc121359ad8567
 UMPF_SRC_URI += "\
   file://patches/0101-ARM-i.MX8MP-skov-halt-startup-until-power-is-good.patch \
   file://patches/0102-ARM-i.MX8MP-skov-halt-startup-until-power-is-good.patch \
@@ -18,27 +19,27 @@ UMPF_SRC_URI += "\
   "
 # umpf-topic: v2025.02.0/customers/skov/arm9cpu
 # umpf-hashinfo: e534542da7f998677e29802bb8b067ca99ccbbe0
-# umpf-topic-range: 4d0e135569ea91805a8e768afc3f0fe99c9d44bb..1815f41f3e9977b0cfbc90312f90656ab5080397
+# umpf-topic-range: 7e222e120f539b892eefea4e2cbc121359ad8567..7b0b53a829eb7bb3d194f4481839f9956bc81b12
 UMPF_SRC_URI += "\
   file://patches/0201-usb-ohci-at91-fix-possible-hang-chainloading-barebox.patch \
   file://patches/0202-HACK-ARM-at91-import-AT91Bootstrap-patch-pmc-fix-PLL.patch \
   "
 # umpf-topic: v2025.06.0/customers/skov/backports
 # umpf-hashinfo: 3efb2d5d911c9d5d458796d00c0a2466c75b0ca7
-# umpf-topic-range: 1815f41f3e9977b0cfbc90312f90656ab5080397..a47827f742dabcf9738b8fe126e6da44f724c3e5
+# umpf-topic-range: 7b0b53a829eb7bb3d194f4481839f9956bc81b12..96424a108523a95c825b8f9628c4cc65badbbc91
 UMPF_SRC_URI += "\
   file://patches/0301-mci-imx-esdhc-restore-longer-timeouts-for-idle.patch \
   file://patches/0302-mci-sdhci-fix-too-short-timeout-in-sdhci_wait_idle_d.patch \
   "
 # umpf-topic: v2025.04.0/topic/imx6-clk
 # umpf-hashinfo: 77c953e6806c34e7b15560e521809f3dd3a024ae
-# umpf-topic-range: a47827f742dabcf9738b8fe126e6da44f724c3e5..66ee5bf8939aff9f15a35b2bada16fad9123676b
+# umpf-topic-range: 96424a108523a95c825b8f9628c4cc65badbbc91..0ac49a377b6a09ab85d4d03ab9cf4efd156f7b1d
 UMPF_SRC_URI += "\
   file://patches/0401-video-IPUv3-LDB-fix-LVDS-serial-clock-configuration.patch \
   "
 # umpf-topic: v2025.06.0/topic/arm-optee-early-helper
 # umpf-hashinfo: c0b787bc8499c1aff302f5c9a76c56b60e7bb7c2
-# umpf-topic-range: 66ee5bf8939aff9f15a35b2bada16fad9123676b..3731192115c329e931625e148ccf662ed47506de
+# umpf-topic-range: 0ac49a377b6a09ab85d4d03ab9cf4efd156f7b1d..4eb4123047da842da2a8297a9d5cf253a12c5399
 UMPF_SRC_URI += "\
   file://patches/0501-pbl-add-panic_no_stacktrace.patch \
   file://patches/0502-arch-Allow-data_abort_mask-in-PBL.patch \
@@ -56,14 +57,14 @@ UMPF_SRC_URI += "\
   file://patches/0514-ARM-i.MX-tqma6ulx-use-ENTRY_FUNCTION_WITHSTACK.patch \
   file://patches/0515-ARM-mach-imx-tzasc-keep-default-region-0-secure-sett.patch \
   "
-# umpf-release: 2025.06.1/customers/skov/imx6/20251126-1
-# umpf-topic-range: 3731192115c329e931625e148ccf662ed47506de..f021235848b381e29ee30e1118bbd4abcd4600b3
+# umpf-release: 2025.06.1/customers/skov/imx6/20260619-1
+# umpf-topic-range: 4eb4123047da842da2a8297a9d5cf253a12c5399..f96fcbdaea9a8f253d69b1187c4b28f54e237cd8
 UMPF_SRC_URI += "\
-  file://patches/0601-Release-2025.06.1-customers-skov-imx6-20251126-1.patch \
+  file://patches/0601-Release-2025.06.1-customers-skov-imx6-20260619-1.patch \
   "
 SRC_URI += "${UMPF_SRC_URI}"
 
 UMPF_BASE = "2025.06.1"
-UMPF_VERSION = "20251126-1"
+UMPF_VERSION = "20260619-1"
 UMPF_PV = "${UMPF_BASE}-${UMPF_VERSION}"
 # umpf-end


### PR DESCRIPTION
Fix the device tree path of the state node for ``LAN2``'s MAC address. It broke in barebox commit [[1]](https://git.pengutronix.de/cgit/barebox/commit/?id=c00df6a4b552) and led to the following error message during boot while fixing up the kernel devicetree:
```
Loading ARM Linux zImage '/mnt/nand0.firmware.ubi.system0//boot/zImage'
Loading devicetree from '/mnt/nand0.firmware.ubi.system0//boot/imx6dl-skov-revc-lt2.dtb'
ERROR: skov-imx6 machine: Node /state/ethaddr/eth2 defining the state variable not found.
```
[1] [c00df6a4b552](https://git.pengutronix.de/cgit/barebox/commit/?id=c00df6a4b552) ("ARM: dts: Fix dtc warnings in state nodes")