### PR TITLE
Use Full 128 Bit SoC UID on i.MX8MP

### DIFF
--- a/recipes-kernel/linux/linux-skov/imx6-cpu/defconfig
+++ b/recipes-kernel/linux/linux-skov/imx6-cpu/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.14.11-20251126-1 Kernel Configuration
+# Linux/arm 6.14.11-20260811-1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-pmc-linux-gnueabi-gcc (GCC) 13.4.0"
 CONFIG_CC_IS_GCC=y

--- a/recipes-kernel/linux/linux-skov/imx8-cpu/defconfig
+++ b/recipes-kernel/linux/linux-skov/imx8-cpu/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.14.11-20251126-1 Kernel Configuration
+# Linux/arm64 6.14.11-20260811-1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-pmc-linux-gcc (GCC) 13.4.0"
 CONFIG_CC_IS_GCC=y

--- a/recipes-kernel/linux/linux-skov/imx8s-cpu/defconfig
+++ b/recipes-kernel/linux/linux-skov/imx8s-cpu/defconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.14.11-20251126-1 Kernel Configuration
+# Linux/arm64 6.14.11-20260811-1 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-pmc-linux-gcc (GCC) 13.4.0"
 CONFIG_CC_IS_GCC=y

--- a/recipes-kernel/linux/linux-skov/patches/2101-soc-imx8m-Cleanup-with-adding-imx8m_soc_-un-prepare.patch
+++ b/recipes-kernel/linux/linux-skov/patches/2101-soc-imx8m-Cleanup-with-adding-imx8m_soc_-un-prepare.patch
@@ -1,0 +1,244 @@
+From: Peng Fan <peng.fan@nxp.com>
+Date: Wed, 23 Apr 2025 22:37:04 +0800
+Subject: [PATCH] soc: imx8m: Cleanup with adding imx8m_soc_[un]prepare
+
+There is a common flow to i.MX8M family, map OCOTP register base and
+enable ocotp clk first before read Unique ID from OCOTP.
+
+So introduce imx8m_soc_prepare to do ioremap and enable the ocotp clk,
+and introduce imx8m_soc_unprepare to disable the clk and do iounmap.
+
+With this patch, no need to spread the ioremap and clk handling in
+each soc_revision hook.
+
+Signed-off-by: Peng Fan <peng.fan@nxp.com>
+Reviewed-by: Marco Felsch <m.felsch@pengutronix.de>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ drivers/soc/imx/soc-imx8m.c | 133 ++++++++++++++++++++++++--------------------
+ 1 file changed, 72 insertions(+), 61 deletions(-)
+
+diff --git a/drivers/soc/imx/soc-imx8m.c b/drivers/soc/imx/soc-imx8m.c
+index 3ed8161d7d28..c4879947dd2d 100644
+--- a/drivers/soc/imx/soc-imx8m.c
++++ b/drivers/soc/imx/soc-imx8m.c
+@@ -30,7 +30,13 @@
+ 
+ struct imx8_soc_data {
+ 	char *name;
+-	int (*soc_revision)(u32 *socrev, u64 *socuid);
++	const char *ocotp_compatible;
++	int (*soc_revision)(struct platform_device *pdev, u32 *socrev, u64 *socuid);
++};
++
++struct imx8_soc_drvdata {
++	void __iomem *ocotp_base;
++	struct clk *clk;
+ };
+ 
+ #ifdef CONFIG_HAVE_ARM_SMCCC
+@@ -49,30 +55,12 @@ static u32 imx8mq_soc_revision_from_atf(void)
+ static inline u32 imx8mq_soc_revision_from_atf(void) { return 0; };
+ #endif
+ 
+-static int imx8mq_soc_revision(u32 *socrev, u64 *socuid)
++static int imx8mq_soc_revision(struct platform_device *pdev, u32 *socrev, u64 *socuid)
+ {
+-	struct device_node *np __free(device_node) =
+-		of_find_compatible_node(NULL, NULL, "fsl,imx8mq-ocotp");
+-	void __iomem *ocotp_base;
++	struct imx8_soc_drvdata *drvdata = platform_get_drvdata(pdev);
++	void __iomem *ocotp_base = drvdata->ocotp_base;
+ 	u32 magic;
+ 	u32 rev;
+-	struct clk *clk;
+-	int ret;
+-
+-	if (!np)
+-		return -EINVAL;
+-
+-	ocotp_base = of_iomap(np, 0);
+-	if (!ocotp_base)
+-		return -EINVAL;
+-
+-	clk = of_clk_get_by_name(np, NULL);
+-	if (IS_ERR(clk)) {
+-		ret = PTR_ERR(clk);
+-		goto err_clk;
+-	}
+-
+-	clk_prepare_enable(clk);
+ 
+ 	/*
+ 	 * SOC revision on older imx8mq is not available in fuses so query
+@@ -91,55 +79,24 @@ static int imx8mq_soc_revision(u32 *socrev, u64 *socuid)
+ 
+ 	*socrev = rev;
+ 
+-	clk_disable_unprepare(clk);
+-	clk_put(clk);
+-	iounmap(ocotp_base);
+-
+ 	return 0;
+-
+-err_clk:
+-	iounmap(ocotp_base);
+-	return ret;
+ }
+ 
+-static int imx8mm_soc_uid(u64 *socuid)
++static int imx8mm_soc_uid(struct platform_device *pdev, u64 *socuid)
+ {
+-	struct device_node *np __free(device_node) =
+-		of_find_compatible_node(NULL, NULL, "fsl,imx8mm-ocotp");
+-	void __iomem *ocotp_base;
+-	struct clk *clk;
+-	int ret = 0;
++	struct imx8_soc_drvdata *drvdata = platform_get_drvdata(pdev);
++	void __iomem *ocotp_base = drvdata->ocotp_base;
+ 	u32 offset = of_machine_is_compatible("fsl,imx8mp") ?
+ 		     IMX8MP_OCOTP_UID_OFFSET : 0;
+ 
+-	if (!np)
+-		return -EINVAL;
+-
+-	ocotp_base = of_iomap(np, 0);
+-	if (!ocotp_base)
+-		return -EINVAL;
+-
+-	clk = of_clk_get_by_name(np, NULL);
+-	if (IS_ERR(clk)) {
+-		ret = PTR_ERR(clk);
+-		goto err_clk;
+-	}
+-
+-	clk_prepare_enable(clk);
+-
+ 	*socuid = readl_relaxed(ocotp_base + OCOTP_UID_HIGH + offset);
+ 	*socuid <<= 32;
+ 	*socuid |= readl_relaxed(ocotp_base + OCOTP_UID_LOW + offset);
+ 
+-	clk_disable_unprepare(clk);
+-	clk_put(clk);
+-
+-err_clk:
+-	iounmap(ocotp_base);
+-	return ret;
++	return 0;
+ }
+ 
+-static int imx8mm_soc_revision(u32 *socrev, u64 *socuid)
++static int imx8mm_soc_revision(struct platform_device *pdev, u32 *socrev, u64 *socuid)
+ {
+ 	struct device_node *np __free(device_node) =
+ 		of_find_compatible_node(NULL, NULL, "fsl,imx8mm-anatop");
+@@ -156,26 +113,66 @@ static int imx8mm_soc_revision(u32 *socrev, u64 *socuid)
+ 
+ 	iounmap(anatop_base);
+ 
+-	return imx8mm_soc_uid(socuid);
++	return imx8mm_soc_uid(pdev, socuid);
++}
++
++static int imx8m_soc_prepare(struct platform_device *pdev, const char *ocotp_compatible)
++{
++	struct device_node *np __free(device_node) =
++		of_find_compatible_node(NULL, NULL, ocotp_compatible);
++	struct imx8_soc_drvdata *drvdata = platform_get_drvdata(pdev);
++	int ret = 0;
++
++	if (!np)
++		return -EINVAL;
++
++	drvdata->ocotp_base = of_iomap(np, 0);
++	if (!drvdata->ocotp_base)
++		return -EINVAL;
++
++	drvdata->clk = of_clk_get_by_name(np, NULL);
++	if (IS_ERR(drvdata->clk)) {
++		ret = PTR_ERR(drvdata->clk);
++		goto err_clk;
++	}
++
++	return clk_prepare_enable(drvdata->clk);
++
++err_clk:
++	iounmap(drvdata->ocotp_base);
++	return ret;
++}
++
++static void imx8m_soc_unprepare(struct platform_device *pdev)
++{
++	struct imx8_soc_drvdata *drvdata = platform_get_drvdata(pdev);
++
++	clk_disable_unprepare(drvdata->clk);
++	clk_put(drvdata->clk);
++	iounmap(drvdata->ocotp_base);
+ }
+ 
+ static const struct imx8_soc_data imx8mq_soc_data = {
+ 	.name = "i.MX8MQ",
++	.ocotp_compatible = "fsl,imx8mq-ocotp",
+ 	.soc_revision = imx8mq_soc_revision,
+ };
+ 
+ static const struct imx8_soc_data imx8mm_soc_data = {
+ 	.name = "i.MX8MM",
++	.ocotp_compatible = "fsl,imx8mm-ocotp",
+ 	.soc_revision = imx8mm_soc_revision,
+ };
+ 
+ static const struct imx8_soc_data imx8mn_soc_data = {
+ 	.name = "i.MX8MN",
++	.ocotp_compatible = "fsl,imx8mm-ocotp",
+ 	.soc_revision = imx8mm_soc_revision,
+ };
+ 
+ static const struct imx8_soc_data imx8mp_soc_data = {
+ 	.name = "i.MX8MP",
++	.ocotp_compatible = "fsl,imx8mm-ocotp",
+ 	.soc_revision = imx8mm_soc_revision,
+ };
+ 
+@@ -207,6 +204,7 @@ static int imx8m_soc_probe(struct platform_device *pdev)
+ 	struct soc_device_attribute *soc_dev_attr;
+ 	struct platform_device *cpufreq_dev;
+ 	const struct imx8_soc_data *data;
++	struct imx8_soc_drvdata *drvdata;
+ 	struct device *dev = &pdev->dev;
+ 	const struct of_device_id *id;
+ 	struct soc_device *soc_dev;
+@@ -218,6 +216,12 @@ static int imx8m_soc_probe(struct platform_device *pdev)
+ 	if (!soc_dev_attr)
+ 		return -ENOMEM;
+ 
++	drvdata = devm_kzalloc(dev, sizeof(*drvdata), GFP_KERNEL);
++	if (!drvdata)
++		return -ENOMEM;
++
++	platform_set_drvdata(pdev, drvdata);
++
+ 	soc_dev_attr->family = "Freescale i.MX";
+ 
+ 	ret = of_property_read_string(of_root, "model", &soc_dev_attr->machine);
+@@ -231,11 +235,18 @@ static int imx8m_soc_probe(struct platform_device *pdev)
+ 	data = id->data;
+ 	if (data) {
+ 		soc_dev_attr->soc_id = data->name;
++		ret = imx8m_soc_prepare(pdev, data->ocotp_compatible);
++		if (ret)
++			return ret;
++
+ 		if (data->soc_revision) {
+-			ret = data->soc_revision(&soc_rev, &soc_uid);
+-			if (ret)
++			ret = data->soc_revision(pdev, &soc_rev, &soc_uid);
++			if (ret) {
++				imx8m_soc_unprepare(pdev);
+ 				return ret;
++			}
+ 		}
++		imx8m_soc_unprepare(pdev);
+ 	}
+ 
+ 	soc_dev_attr->revision = imx8_revision(dev, soc_rev);

--- a/recipes-kernel/linux/linux-skov/patches/2102-soc-imx8m-Introduce-soc_uid-hook.patch
+++ b/recipes-kernel/linux/linux-skov/patches/2102-soc-imx8m-Introduce-soc_uid-hook.patch
@@ -1,0 +1,140 @@
+From: Peng Fan <peng.fan@nxp.com>
+Date: Wed, 23 Apr 2025 22:37:05 +0800
+Subject: [PATCH] soc: imx8m: Introduce soc_uid hook
+
+Cleanup code by introducing soc_uid hook, i.MX8MQ/M/N could reuse
+one function imx8m_soc_uid, i.MX8MP could have its own one.
+
+With this patch, it will easy to add 128bits UID support for i.MX8MP.
+
+Signed-off-by: Peng Fan <peng.fan@nxp.com>
+Reviewed-by: Marco Felsch <m.felsch@pengutronix.de>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ drivers/soc/imx/soc-imx8m.c | 46 +++++++++++++++++++++++++++++++--------------
+ 1 file changed, 32 insertions(+), 14 deletions(-)
+
+diff --git a/drivers/soc/imx/soc-imx8m.c b/drivers/soc/imx/soc-imx8m.c
+index c4879947dd2d..2186f6ab3edd 100644
+--- a/drivers/soc/imx/soc-imx8m.c
++++ b/drivers/soc/imx/soc-imx8m.c
+@@ -31,7 +31,8 @@
+ struct imx8_soc_data {
+ 	char *name;
+ 	const char *ocotp_compatible;
+-	int (*soc_revision)(struct platform_device *pdev, u32 *socrev, u64 *socuid);
++	int (*soc_revision)(struct platform_device *pdev, u32 *socrev);
++	int (*soc_uid)(struct platform_device *pdev, u64 *socuid);
+ };
+ 
+ struct imx8_soc_drvdata {
+@@ -55,7 +56,19 @@ static u32 imx8mq_soc_revision_from_atf(void)
+ static inline u32 imx8mq_soc_revision_from_atf(void) { return 0; };
+ #endif
+ 
+-static int imx8mq_soc_revision(struct platform_device *pdev, u32 *socrev, u64 *socuid)
++static int imx8m_soc_uid(struct platform_device *pdev, u64 *socuid)
++{
++	struct imx8_soc_drvdata *drvdata = platform_get_drvdata(pdev);
++	void __iomem *ocotp_base = drvdata->ocotp_base;
++
++	*socuid = readl_relaxed(ocotp_base + OCOTP_UID_HIGH);
++	*socuid <<= 32;
++	*socuid |= readl_relaxed(ocotp_base + OCOTP_UID_LOW);
++
++	return 0;
++}
++
++static int imx8mq_soc_revision(struct platform_device *pdev, u32 *socrev)
+ {
+ 	struct imx8_soc_drvdata *drvdata = platform_get_drvdata(pdev);
+ 	void __iomem *ocotp_base = drvdata->ocotp_base;
+@@ -73,30 +86,24 @@ static int imx8mq_soc_revision(struct platform_device *pdev, u32 *socrev, u64 *s
+ 			rev = REV_B1;
+ 	}
+ 
+-	*socuid = readl_relaxed(ocotp_base + OCOTP_UID_HIGH);
+-	*socuid <<= 32;
+-	*socuid |= readl_relaxed(ocotp_base + OCOTP_UID_LOW);
+-
+ 	*socrev = rev;
+ 
+ 	return 0;
+ }
+ 
+-static int imx8mm_soc_uid(struct platform_device *pdev, u64 *socuid)
++static int imx8mp_soc_uid(struct platform_device *pdev, u64 *socuid)
+ {
+ 	struct imx8_soc_drvdata *drvdata = platform_get_drvdata(pdev);
+ 	void __iomem *ocotp_base = drvdata->ocotp_base;
+-	u32 offset = of_machine_is_compatible("fsl,imx8mp") ?
+-		     IMX8MP_OCOTP_UID_OFFSET : 0;
+ 
+-	*socuid = readl_relaxed(ocotp_base + OCOTP_UID_HIGH + offset);
++	*socuid = readl_relaxed(ocotp_base + OCOTP_UID_HIGH + IMX8MP_OCOTP_UID_OFFSET);
+ 	*socuid <<= 32;
+-	*socuid |= readl_relaxed(ocotp_base + OCOTP_UID_LOW + offset);
++	*socuid |= readl_relaxed(ocotp_base + OCOTP_UID_LOW + IMX8MP_OCOTP_UID_OFFSET);
+ 
+ 	return 0;
+ }
+ 
+-static int imx8mm_soc_revision(struct platform_device *pdev, u32 *socrev, u64 *socuid)
++static int imx8mm_soc_revision(struct platform_device *pdev, u32 *socrev)
+ {
+ 	struct device_node *np __free(device_node) =
+ 		of_find_compatible_node(NULL, NULL, "fsl,imx8mm-anatop");
+@@ -113,7 +120,7 @@ static int imx8mm_soc_revision(struct platform_device *pdev, u32 *socrev, u64 *s
+ 
+ 	iounmap(anatop_base);
+ 
+-	return imx8mm_soc_uid(pdev, socuid);
++	return 0;
+ }
+ 
+ static int imx8m_soc_prepare(struct platform_device *pdev, const char *ocotp_compatible)
+@@ -156,24 +163,28 @@ static const struct imx8_soc_data imx8mq_soc_data = {
+ 	.name = "i.MX8MQ",
+ 	.ocotp_compatible = "fsl,imx8mq-ocotp",
+ 	.soc_revision = imx8mq_soc_revision,
++	.soc_uid = imx8m_soc_uid,
+ };
+ 
+ static const struct imx8_soc_data imx8mm_soc_data = {
+ 	.name = "i.MX8MM",
+ 	.ocotp_compatible = "fsl,imx8mm-ocotp",
+ 	.soc_revision = imx8mm_soc_revision,
++	.soc_uid = imx8m_soc_uid,
+ };
+ 
+ static const struct imx8_soc_data imx8mn_soc_data = {
+ 	.name = "i.MX8MN",
+ 	.ocotp_compatible = "fsl,imx8mm-ocotp",
+ 	.soc_revision = imx8mm_soc_revision,
++	.soc_uid = imx8m_soc_uid,
+ };
+ 
+ static const struct imx8_soc_data imx8mp_soc_data = {
+ 	.name = "i.MX8MP",
+ 	.ocotp_compatible = "fsl,imx8mm-ocotp",
+ 	.soc_revision = imx8mm_soc_revision,
++	.soc_uid = imx8mp_soc_uid,
+ };
+ 
+ static __maybe_unused const struct of_device_id imx8_soc_match[] = {
+@@ -240,7 +251,14 @@ static int imx8m_soc_probe(struct platform_device *pdev)
+ 			return ret;
+ 
+ 		if (data->soc_revision) {
+-			ret = data->soc_revision(pdev, &soc_rev, &soc_uid);
++			ret = data->soc_revision(pdev, &soc_rev);
++			if (ret) {
++				imx8m_soc_unprepare(pdev);
++				return ret;
++			}
++		}
++		if (data->soc_uid) {
++			ret = data->soc_uid(pdev, &soc_uid);
+ 			if (ret) {
+ 				imx8m_soc_unprepare(pdev);
+ 				return ret;

--- a/recipes-kernel/linux/linux-skov/patches/2103-soc-imx8m-Dump-higher-64bits-UID.patch
+++ b/recipes-kernel/linux/linux-skov/patches/2103-soc-imx8m-Dump-higher-64bits-UID.patch
@@ -1,0 +1,79 @@
+From: Peng Fan <peng.fan@nxp.com>
+Date: Wed, 23 Apr 2025 22:37:06 +0800
+Subject: [PATCH] soc: imx8m: Dump higher 64bits UID
+
+i.MX8MP UID is actually 128bits and partitioned into two parts.
+The 1st 64bits are at 0x410 and 0x420, and 2nd 64bits are at 0xE00
+and 0xE10.
+
+Dump the whole 128bits for i.MX8MP, by set soc_uid as an array with two
+u64.
+
+Signed-off-by: Peng Fan <peng.fan@nxp.com>
+Reviewed-by: Marco Felsch <m.felsch@pengutronix.de>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ drivers/soc/imx/soc-imx8m.c | 22 ++++++++++++++++------
+ 1 file changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/soc/imx/soc-imx8m.c b/drivers/soc/imx/soc-imx8m.c
+index 2186f6ab3edd..04a1b60f2f2b 100644
+--- a/drivers/soc/imx/soc-imx8m.c
++++ b/drivers/soc/imx/soc-imx8m.c
+@@ -24,6 +24,7 @@
+ #define OCOTP_UID_HIGH			0x420
+ 
+ #define IMX8MP_OCOTP_UID_OFFSET		0x10
++#define IMX8MP_OCOTP_UID_HIGH		0xE00
+ 
+ /* Same as ANADIG_DIGPROG_IMX7D */
+ #define ANADIG_DIGPROG_IMX8MM	0x800
+@@ -96,9 +97,13 @@ static int imx8mp_soc_uid(struct platform_device *pdev, u64 *socuid)
+ 	struct imx8_soc_drvdata *drvdata = platform_get_drvdata(pdev);
+ 	void __iomem *ocotp_base = drvdata->ocotp_base;
+ 
+-	*socuid = readl_relaxed(ocotp_base + OCOTP_UID_HIGH + IMX8MP_OCOTP_UID_OFFSET);
+-	*socuid <<= 32;
+-	*socuid |= readl_relaxed(ocotp_base + OCOTP_UID_LOW + IMX8MP_OCOTP_UID_OFFSET);
++	socuid[0] = readl_relaxed(ocotp_base + OCOTP_UID_HIGH + IMX8MP_OCOTP_UID_OFFSET);
++	socuid[0] <<= 32;
++	socuid[0] |= readl_relaxed(ocotp_base + OCOTP_UID_LOW + IMX8MP_OCOTP_UID_OFFSET);
++
++	socuid[1] = readl_relaxed(ocotp_base + IMX8MP_OCOTP_UID_HIGH + 0x10);
++	socuid[1] <<= 32;
++	socuid[1] |= readl_relaxed(ocotp_base + IMX8MP_OCOTP_UID_HIGH);
+ 
+ 	return 0;
+ }
+@@ -220,7 +225,7 @@ static int imx8m_soc_probe(struct platform_device *pdev)
+ 	const struct of_device_id *id;
+ 	struct soc_device *soc_dev;
+ 	u32 soc_rev = 0;
+-	u64 soc_uid = 0;
++	u64 soc_uid[2] = {0, 0};
+ 	int ret;
+ 
+ 	soc_dev_attr = devm_kzalloc(dev, sizeof(*soc_dev_attr), GFP_KERNEL);
+@@ -258,7 +263,7 @@ static int imx8m_soc_probe(struct platform_device *pdev)
+ 			}
+ 		}
+ 		if (data->soc_uid) {
+-			ret = data->soc_uid(pdev, &soc_uid);
++			ret = data->soc_uid(pdev, soc_uid);
+ 			if (ret) {
+ 				imx8m_soc_unprepare(pdev);
+ 				return ret;
+@@ -271,7 +276,12 @@ static int imx8m_soc_probe(struct platform_device *pdev)
+ 	if (!soc_dev_attr->revision)
+ 		return -ENOMEM;
+ 
+-	soc_dev_attr->serial_number = devm_kasprintf(dev, GFP_KERNEL, "%016llX", soc_uid);
++	if (soc_uid[1])
++		soc_dev_attr->serial_number = devm_kasprintf(dev, GFP_KERNEL, "%016llX%016llX",
++							     soc_uid[1], soc_uid[0]);
++	else
++		soc_dev_attr->serial_number = devm_kasprintf(dev, GFP_KERNEL, "%016llX",
++							     soc_uid[0]);
+ 	if (!soc_dev_attr->serial_number)
+ 		return -ENOMEM;
+ 

--- a/recipes-kernel/linux/linux-skov/patches/2201-Release-6.14-customers-skov-imx6-20260811-1.patch
+++ b/recipes-kernel/linux/linux-skov/patches/2201-Release-6.14-customers-skov-imx6-20260811-1.patch
@@ -1,13 +1,13 @@
 From: =?UTF-8?q?Ulrich=20=C3=96lmann?= <u.oelmann@pengutronix.de>
-Date: Wed, 26 Nov 2025 14:06:18 +0100
-Subject: [PATCH] Release 6.14/customers/skov/imx6/20251126-1
+Date: Tue, 11 Aug 2026 15:22:47 +0200
+Subject: [PATCH] Release 6.14/customers/skov/imx6/20260811-1
 
 ---
  Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 48d2ce96398b..f954ea3121b5 100644
+index 48d2ce96398b..1ec01277a554 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -2,7 +2,7 @@
@@ -15,7 +15,7 @@ index 48d2ce96398b..f954ea3121b5 100644
  PATCHLEVEL = 14
  SUBLEVEL = 11
 -EXTRAVERSION =
-+EXTRAVERSION =-20251126-1
++EXTRAVERSION =-20260811-1
  NAME = Baby Opossum Posse
  
  # *DOCUMENTATION*

--- a/recipes-kernel/linux/linux-skov/patches/series.inc
+++ b/recipes-kernel/linux/linux-skov/patches/series.inc
@@ -1,6 +1,6 @@
 # umpf-base: v6.14.11
 # umpf-name: 6.14/customers/skov/imx6
-# umpf-version: 6.14/customers/skov/imx6/20251126-1
+# umpf-version: 6.14/customers/skov/imx6/20260811-1
 # umpf-topic: v6.12/topic/drm-sched-accounting
 # umpf-hashinfo: a886925c1b1aedf839db4297e1b6a8e87e01b63d
 # umpf-topic-range: b9d5d463c216763cec719c04536ea9e14512cad4..a522d517242f4bf26bcfb8b64f179ffce4d108af
@@ -191,15 +191,23 @@ UMPF_SRC_URI += "\
 UMPF_SRC_URI += "\
   file://patches/2001-tee-shm-fix-slab-page-refcounting.patch \
   "
-# umpf-release: 6.14/customers/skov/imx6/20251126-1
-# umpf-topic-range: 89d8f6d64dc963b50cb697c4a6fd4d511cd7c3ff..91cbdce96e7724ebd013e63c929d97cc9ce80375
+# umpf-topic: v6.14/customers/skov/backports
+# umpf-hashinfo: 55df8bf88d9fa11e63621d96ab9f175f19a1a8e6
+# umpf-topic-range: 89d8f6d64dc963b50cb697c4a6fd4d511cd7c3ff..bf5df00cd095d7041d9ef0e16e840ad2116c335c
 UMPF_SRC_URI += "\
-  file://patches/2101-Release-6.14-customers-skov-imx6-20251126-1.patch \
+  file://patches/2101-soc-imx8m-Cleanup-with-adding-imx8m_soc_-un-prepare.patch \
+  file://patches/2102-soc-imx8m-Introduce-soc_uid-hook.patch \
+  file://patches/2103-soc-imx8m-Dump-higher-64bits-UID.patch \
+  "
+# umpf-release: 6.14/customers/skov/imx6/20260811-1
+# umpf-topic-range: bf5df00cd095d7041d9ef0e16e840ad2116c335c..576f8e27efcbd32b811ba1cc4053ce0710e6e07b
+UMPF_SRC_URI += "\
+  file://patches/2201-Release-6.14-customers-skov-imx6-20260811-1.patch \
   "
 SRC_URI += "${UMPF_SRC_URI}"
 
 UMPF_BASE = "6.14.11"
-UMPF_VERSION = "20251126-1"
+UMPF_VERSION = "20260811-1"
 UMPF_PV = "${UMPF_BASE}-${UMPF_VERSION}"
 LINUX_VERSION ?= "${UMPF_BASE}"
 # umpf-end


### PR DESCRIPTION
Backport the upstream i.MX8M patch series [[1]](https://lore.kernel.org/all/20250423-uid-128-v2-0-327c30fe59a9@nxp.com/) that adds support for exposing the full 128-bit UID of the i.MX8MP to Linux userspace from v6.16. This is done in preparation for the upcoming barebox security policies, where the full UID could then be used to derive device-specific access tokens.

Before this patch:
```
  root@imx8s-cpu:~# cat /sys/devices/soc0/serial_number
  141A5800B5B495A3
```
After this patch:
```
  root@imx8s-cpu:~# cat /sys/devices/soc0/serial_number
  46966F3E0618C9E7141A5800B5B495A3
```
[1] https://lore.kernel.org/all/20250423-uid-128-v2-0-327c30fe59a9@nxp.com/